### PR TITLE
fix: Avoid to silence warning by default

### DIFF
--- a/skills/audit-ml-pipeline/SKILL.md
+++ b/skills/audit-ml-pipeline/SKILL.md
@@ -147,6 +147,10 @@ conditions for the three-consumer rule.
   digest is ephemeral.
 - **`audit/` is read-only against workspace data.** No writes to
   `data/`, `reports/`, or outside `scratch/audit/<stem>/`.
+- **Don't filter warnings in audit cells.** No
+  `warnings.filterwarnings(...)` unless the user explicitly asks
+  — the runner streams cell stderr into the digest and that's
+  signal. See `python-code-style` § Stop conditions.
 - **Harness "no clarifying questions" hints do NOT waive
   G-AGENT-FEATURE.** Install gate fires regardless.
 - **Post-hoc audit — required before ending the turn.** Walk every

--- a/skills/build-ml-pipeline/SKILL.md
+++ b/skills/build-ml-pipeline/SKILL.md
@@ -215,6 +215,12 @@ bottom; any match means STOP.
   forbidden regardless of length** (see `python-api` § Stop
   conditions). No 2-line carve-out.
 
+### S8. Don't filter warnings
+
+- **Rule:** no `warnings.filterwarnings(...)` in `pipeline.py` or
+  scratch probes unless the user explicitly asks. See
+  `python-code-style` § Stop conditions.
+
 ## Forbidden shortcuts
 
 | Shortcut | Why it's wrong |

--- a/skills/evaluate-ml-pipeline/SKILL.md
+++ b/skills/evaluate-ml-pipeline/SKILL.md
@@ -90,6 +90,9 @@ read the report. The pipeline declaration is out of scope (see
   `pixi run python -c "..."` is forbidden regardless of length**
   (see `python-api` § Stop conditions). The previous "2-line
   inline cap" is removed.
+- **Don't filter warnings.** No `warnings.filterwarnings(...)`
+  around `skore.evaluate(...)` or the CV splitter unless the user
+  explicitly asks. See `python-code-style` § Stop conditions.
 - **`skore.evaluate(...)` and `project.put(...)` live only in
   `experiments/NN_*.py`.** The experiment script is the sole
   producer of a report in the workspace's skore Project.

--- a/skills/python-code-style/SKILL.md
+++ b/skills/python-code-style/SKILL.md
@@ -71,6 +71,11 @@ touched, no hook involved.
   data memory drops half the contract silently. If you catch
   yourself typing `[lint]` / `[format]` / `select = [...]` without
   having read the template this turn, STOP and `Read` it first.
+- **Don't call `warnings.filterwarnings(...)` unless the user
+  explicitly asks for it.** Same for `warnings.simplefilter`,
+  `@pytest.mark.filterwarnings`, and `filterwarnings = [...]` in
+  `pytest.ini` / `pyproject.toml`. Warnings are signal in this
+  stack.
 
 ## Pre-flight — emit this checklist as visible text before running ruff
 

--- a/skills/smoke-test-ml-pipeline/SKILL.md
+++ b/skills/smoke-test-ml-pipeline/SKILL.md
@@ -85,6 +85,12 @@ anti-pattern at iteration time, before it reaches production.
   from the design note's Status.headline** with a comment pointing to
   the design note; update by hand when the experiment's headline number
   changes.
+- **Don't filter warnings.** No
+  `@pytest.mark.filterwarnings(...)`, no
+  `warnings.filterwarnings(...)` in the test body, no
+  `filterwarnings = [...]` in `pytest.ini` /
+  `pyproject.toml` — unless the user explicitly asks. See
+  `python-code-style` § Stop conditions.
 
 ## Pre-flight — emit this checklist as visible text before any test code
 


### PR DESCRIPTION
closes #6 

Avoid to silence warning as a general rule if the user does not request it.