### PR TITLE
feat: Add the option to push to MLflow via Skore

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -2,7 +2,7 @@
   "name": "probabl-skills",
   "version": "0.3.0",
   "description": "Skills to support Machine Learning experimentation using the Python ecosystem.",
-  "catalog_hash": "7e67e8cb8df673740fb9300e002d9a7cd641dd7e22d20eef240fba2a902c378a",
+  "catalog_hash": "88f51d552ffec83de7afa0e7b31a324c00e2708d3445108e9d137ec4c2ef5c12",
   "skills": [
     {
       "id": "build-ml-pipeline",
@@ -47,7 +47,7 @@
       "summary": "Once testing and the experiment is done, audit by loading a skore report and investigate.",
       "category": "methodology",
       "subcategory": null,
-      "hash": "9b57aa8cc91050b747a9fd56ffda3835c982f0b2b3f17f9599eac40447a2e076"
+      "hash": "472b58ba5ea84a335e7cfd15bb36a060a35d069ef37724eba35315cfb82fee2e"
     },
     {
       "id": "iterate-ml-experiment",
@@ -56,7 +56,7 @@
       "summary": "Design, keep track of experiments and iterate on them.",
       "category": "orchestration",
       "subcategory": "dispatchers",
-      "hash": "058c9bc3062651efd9a7adfb584f7b45dd7768cec7462a381edf8e8ce6da4d2c"
+      "hash": "d1a2e0e05b522df3969f97e87d8a8b43ab894f6b46aabb9958045094b9004371"
     },
     {
       "id": "iterate-from-skore",
@@ -83,7 +83,7 @@
       "summary": "An organized workspace to keep track of your experiments.",
       "category": "tooling",
       "subcategory": "project-setup",
-      "hash": "bb0122de1d37ca42d31f60f8f374854fe77fad5bab5da4b075e7be47145c08dc"
+      "hash": "8d78277795a4db48d2315e7ebeabb44a4b720d060b0770f5545c064cee0b1831"
     },
     {
       "id": "python-code-style",
@@ -101,7 +101,7 @@
       "summary": "Bootstrapping the experiment setup based on your favorite Python environment manager.",
       "category": "tooling",
       "subcategory": "project-setup",
-      "hash": "36d5990583d33d51c20224b073654b6e1ec7498fc86681182b6c8036c69f1074"
+      "hash": "5a90b93d78b4d3d06be4c80277f520fcd5d644722dade7813584c3d5fa8567f1"
     },
     {
       "id": "data-science-python-stack",
@@ -110,7 +110,7 @@
       "summary": "Opinionated one-library-per-job Python stack, organized into mandatory / user-choice / optional / transitive tiers.",
       "category": "reference",
       "subcategory": null,
-      "hash": "726b39e920ab92d59354758eac4d9e4625c7af66fa678f113a5c36ae64752fa9"
+      "hash": "48885acffcb9fe722e715aae472f719a6009de78021cf258bdd8d9b110ee2304"
     },
     {
       "id": "python-api",
@@ -119,7 +119,7 @@
       "summary": "Discover the public API of any installed Python package to make agent find their way without bothering your workspace.",
       "category": "reference",
       "subcategory": null,
-      "hash": "a884eebc7fc3bb7ad8488b5a18b2305fc586c2db86daaf6276dd101092575877"
+      "hash": "8f82b9c88f898657a833f683340da63ec152a4ef3b538b0c7253ba5fdf67df99"
     }
   ],
   "workflows": [

--- a/skills/audit-ml-pipeline/SKILL.md
+++ b/skills/audit-ml-pipeline/SKILL.md
@@ -255,8 +255,8 @@ Brief outline; full anatomy with concrete examples →
 5. **Load the report** — set `REPORT_ID` from the URL printed by
    `project.put()` (hub: `"skore:report:<type-singular>:<N>"` — URL
    path segment is plural, id uses singular, e.g. `cross-validations`
-   → `cross-validation`, `estimators` → `estimator`; local: read
-   `summary["id"]` for the matching key row), then
+   → `cross-validation`, `estimators` → `estimator`; local **and
+   mlflow**: read `summary["id"]` for the matching key row), then
    `report = project.get(REPORT_ID)`; then `report`.
 6. **Checks summary** — `report.checks.summarize().frame()`. Each row
    carries `documentation_url` — the actionable mitigation for an

--- a/skills/audit-ml-pipeline/references/cell_anatomy.md
+++ b/skills/audit-ml-pipeline/references/cell_anatomy.md
@@ -115,6 +115,10 @@ user asks for a deeper accessor.
      the put() stdout; hardcode as `REPORT_ID`; no `summarize()` needed.
    - **Local mode**: read `summary["id"]` from the `summarize()` cell
      above, filtering to the row where `key == "<NN>_<short_name>"`.
+   - **MLflow mode**: same as local — read `summary["id"]` from the
+     `summarize()` cell above, filtering to the row where
+     `key == "<NN>_<short_name>"`. (No URL is printed at `put()`;
+     the report lives as a run under the MLflow experiment.)
 
    ```python
    REPORT_ID = "skore:report:<type-singular>:<N>"  # hub: from put() URL

--- a/skills/data-science-python-stack/references/mlflow.md
+++ b/skills/data-science-python-stack/references/mlflow.md
@@ -20,6 +20,12 @@ reporting is owned by `skore` reports.
 - The task is **tracking** (params, metrics, artifacts, run
   comparison) → use `skore`'s Project API. Don't reach for
   `mlflow.log_param` / `mlflow.log_metric` / `mlflow.start_run`.
+  Note: if the team wants their skore reports **stored on an MLflow
+  tracking server**, that is still a skore-owned operation — use
+  `skore.Project(mode="mlflow", tracking_uri=...)` (the
+  `skore[mlflow]` backend) and keep calling `project.put(...)`. The
+  mode is picked at `organize-ml-workspace` § "G-SKORE-MODE"; you
+  still never call the raw `mlflow.log_*` API yourself.
 - You only need to evaluate a model and produce a report → use
   `skore`'s `EstimatorReport` / `CrossValidationReport` /
   `ComparisonReport`.

--- a/skills/data-science-python-stack/references/skore.md
+++ b/skills/data-science-python-stack/references/skore.md
@@ -83,21 +83,32 @@ project.get("baseline")
 ```
 
 Use the Project API as the durable home for everything you produce:
-fitted estimators, reports, params, metrics, plots. The project is a
-directory on disk; commits naturally with the code.
+fitted estimators, reports, params, metrics, plots. In the default
+`local` mode the project is a directory on disk; commits naturally
+with the code.
+
+The Project supports **three mutually exclusive backends**, picked
+once per workspace at `organize-ml-workspace` § "G-SKORE-MODE":
+`local` (folder on disk), `hub` (Skore Hub, `skore[hub]`), and
+`mlflow` (push reports to an MLflow tracking server via
+`skore.Project(mode="mlflow", tracking_uri=...)`, `skore[mlflow]`).
+The `put` / `get` / `summarize` surface is identical across all
+three — only the constructor changes shape.
 
 **Pick skore Project API when:**
 - You want tracking that doesn't require a server, a UI, or any
-  network setup — just a folder.
+  network setup — just a folder (`local` mode).
+- You want a shared remote home for reports — `hub` (Skore Hub) or
+  `mlflow` (an existing MLflow tracking server) without leaving the
+  skore Project API.
 - You want to keep the artifact and its evaluation report in the same
   place, retrievable by key.
-- The project is single-user or small-team; the trade-off is no
-  multi-user web UI like mlflow's.
 
 **Pick something else when:**
 - You need a multi-user remote tracking server with a shared web UI
-  across collaborators — that's not skore's target. Surface the gap to
-  the user before substituting.
+  and neither Skore Hub (`hub` mode) nor an MLflow server
+  (`mlflow` mode) fits — surface the gap to the user before
+  substituting.
 
 ## Pair with
 

--- a/skills/iterate-ml-experiment/SKILL.md
+++ b/skills/iterate-ml-experiment/SKILL.md
@@ -238,7 +238,7 @@ placeholder, or has 0 History rows.
 | `G-PKG-NAME` | `src/<pkg>/` import name | `organize-ml-workspace` | before manifest creation |
 | `G-ENV-MGR` | Env manager | `python-env-manager` | before any install command |
 | `G-TABULAR` | Tabular library (pandas / polars) | `data-science-python-stack` | before `data.py` write |
-| `G-SKORE-MODE` | Skore Project mode (local / hub) + hub workspace name | `organize-ml-workspace` | before `pyproject.toml` write |
+| `G-SKORE-MODE` | Skore Project mode (local / hub / mlflow) + hub workspace name or MLflow tracking URI | `organize-ml-workspace` | before `pyproject.toml` write |
 | `G-CV-SPLITTER` | CV family for `skore.evaluate` | `evaluate-ml-pipeline` | before `evaluate.py` write — mandatory even with empty `split_kwargs` |
 | `G-DESIGN` | User approval of `journal/01_baseline.md` | this skill | before `experiments/01_baseline.py` write |
 | `G-RUN` | "run now" vs "leave for later" | this skill | before executing the experiment script |

--- a/skills/iterate-ml-experiment/templates/JOURNAL.md
+++ b/skills/iterate-ml-experiment/templates/JOURNAL.md
@@ -54,8 +54,9 @@ install (ipython + pyright + pyrightconfig.json) or skipped it.
   - agent feature: <installed | skipped> — recorded: <YYYY-MM-DD>
   - optional features: <name1, name2 | none> — recorded: <YYYY-MM-DD>
   - package name (`src/<pkg>/`): <pkg> — recorded: <YYYY-MM-DD>
-  - skore mode: <local | hub> — recorded: <YYYY-MM-DD>
+  - skore mode: <local | hub | mlflow> — recorded: <YYYY-MM-DD>
   - skore hub workspace: <hub-workspace-name | n/a> — recorded: <YYYY-MM-DD>
+  - skore mlflow tracking uri: <mlflow-tracking-uri | n/a> — recorded: <YYYY-MM-DD>
   - CV splitter family: <KFold | StratifiedKFold | GroupKFold | TimeSeriesSplit | other> — recorded: <YYYY-MM-DD>
 
 ## History

--- a/skills/organize-ml-workspace/SKILL.md
+++ b/skills/organize-ml-workspace/SKILL.md
@@ -110,12 +110,14 @@ Sibling skills (just-in-time):
 - **Skore Project mode is asked, not assumed (G-SKORE-MODE).**
   Before any template instantiation containing
   `skore.Project(...)`, fire an `AskUserQuestion` for `local` |
-  `hub`. Default proposal: `local`. Hub triggers a follow-up for
-  the workspace name (org/team on the hub — distinct from
-  local-mode `workspace=`). Persists as `skore mode:` (+
-  `skore hub workspace:` when hub). Without it the
-  `<SKORE_PROJECT_INIT>` substitution has no shape to fill.
-  Details: → `references/g_skore_mode.md`.
+  `hub` | `mlflow`. Default proposal: `local`. Hub triggers a
+  follow-up for the workspace name (org/team on the hub — distinct
+  from local-mode `workspace=`); mlflow triggers a follow-up for
+  the **MLflow tracking server URI** (`tracking_uri=`) — the agent
+  cannot infer it. Persists as `skore mode:` (+ `skore hub
+  workspace:` when hub, + `skore mlflow tracking uri:` when
+  mlflow). Without it the `<SKORE_PROJECT_INIT>` substitution has
+  no shape to fill. Details: → `references/g_skore_mode.md`.
 - **Switching skore mode mid-project is forbidden by default.**
   Once recorded, do not silently change. A switch orphans every
   existing report in the prior store — skore has no built-in
@@ -150,9 +152,11 @@ Sibling skills (just-in-time):
 | Batch G-TABULAR + G-PKG-NAME + G-ENV-MGR + G-SKORE-MODE into prose recommendations | The gates take structured `AskUserQuestion`. Prose followed by "let me know" does NOT resolve them |
 | Skip G-SKORE-MODE because templates use `mode="local"` | Templates carry the `<SKORE_PROJECT_INIT>` marker, not a literal. The gate must fire |
 | Pick `mode="hub"` without checking the workspace exists / user has access | Project init fails at first `put()` with an authorization error. Confirm during G-SKORE-MODE, not at execution time |
-| Substitute `pip install "skore[hub]"` based on agent guess | Install variant comes from G-SKORE-MODE's recorded answer. `python-env-manager` reads that row, not agent intuition |
+| Pick `mode="mlflow"` and invent / default the `tracking_uri=` | The tracking URI is server-specific; the agent cannot infer it. Ask the user at the G-SKORE-MODE follow-up. No silent `http://localhost:5000` |
+| Substitute `pip install "skore[hub]"` / `"skore[mlflow]"` based on agent guess | Install variant comes from G-SKORE-MODE's recorded answer. `python-env-manager` reads that row, not agent intuition |
 | Silently change `skore mode:` mid-project to "fix" a broken init | Switching orphans existing reports. Always explicit `AskUserQuestion` first |
-| Hub substitution but leaving `workspace=` kwarg | `workspace=` is local-only; hub raises `TypeError`. Substitute the whole block, not just the mode literal |
+| Hub / mlflow substitution but leaving `workspace=` kwarg | `workspace=` is local-only; hub and mlflow reject it (hub raises `TypeError`; mlflow uses `tracking_uri=`). Substitute the whole block, not just the mode literal |
+| mlflow substitution that keeps a `login(mode=...)` call | mlflow mode needs no skore login — auth is the MLflow server's concern. `login` belongs only to hub mode |
 | Local `workspace="reports"` (relative) instead of `str(PROJECT_ROOT / "reports")` (absolute) | Relative resolves against CWD; runs from other dirs write the store somewhere unexpected. Always absolute via `PROJECT_ROOT` |
 | Putting `skore.login(mode="hub")` after `skore.Project(...)` | `Project(...)` requires authenticated session in hub mode. `login` first |
 | Substituting `<SKORE_PROJECT_INIT>` in `audit/<stem>.py` independently of `experiments/<stem>.py` | Audit must open the same Project. Byte-identical copy from the experiment file is the rule |
@@ -187,10 +191,11 @@ Pre-flight (organize-ml-workspace):
                 JOURNAL.md Status (Workspace decisions) |
                 existing manifest's [project].name **confirmed via AskUserQuestion**
                 (reading the manifest alone is NOT sufficient)
-- [ ] G-SKORE-MODE resolved: local | hub
-      Evidence: AskUserQuestion id=<id>, answer=<local|hub> |
+- [ ] G-SKORE-MODE resolved: local | hub | mlflow
+      Evidence: AskUserQuestion id=<id>, answer=<local|hub|mlflow> |
                 JOURNAL.md Status (Workspace decisions) `skore mode:` row
       If hub: also captures `skore hub workspace:` row.
+      If mlflow: also captures `skore mlflow tracking uri:` row.
 - [ ] `pyproject.toml` present at root declaring `src/<pkg>/`;
       editable install wired via `python-env-manager` § Editable workspace
       Evidence: Read pyproject.toml (this turn) + manager's editable-install call
@@ -316,7 +321,7 @@ revisiting the matching smoke test
 |---|---|---|
 | 1 | Read project root; Detection table matches → glue (stop). No match → continue | this skill |
 | 2 | **G-PKG-NAME** structured ask. Record in `Workspace decisions`. No manager `init` until this passes | this skill |
-| 2a | **G-SKORE-MODE** ask: local | hub (+ hub workspace name if hub). Determines `<SKORE_PROJECT_INIT>` form + skore install variant. → `references/g_skore_mode.md` | this skill |
+| 2a | **G-SKORE-MODE** ask: local | hub | mlflow (+ hub workspace name if hub; + MLflow tracking URI if mlflow). Determines `<SKORE_PROJECT_INIT>` form + skore install variant. → `references/g_skore_mode.md` | this skill |
 | 3 | Drop `pyproject.toml` from `templates/pyproject.toml` (substitute `<pkg>`). Hand off to `python-env-manager` for editable install | this skill → env-manager |
 | 4 | Create `src/<pkg>/` with skeletons from `templates/src_*.py` | this skill |
 | 5 | Create `experiments/01_baseline.py` from `templates/experiment.py` (substitute `<pkg>`, `<SKORE_PROJECT_INIT>` per G-SKORE-MODE, `<project-name>`) | this skill |
@@ -356,7 +361,8 @@ Each has a narrow contract:
 `# %%` cell markers, not `.ipynb`. Template:
 `templates/experiment.py`. What the script does:
 
-1. Open / attach to the `skore.Project` at `reports/` (or hub).
+1. Open / attach to the `skore.Project` at `reports/` (or hub /
+   mlflow server, per `skore mode:`).
 2. Import the learner from `<pkg>.pipeline` and CV from
    `<pkg>.evaluate`.
 3. Call `skore.evaluate(...)`.
@@ -367,7 +373,7 @@ Confirm signatures via `python-api`. Cross-validator choice is
 
 **Project init substitution** — the `<SKORE_PROJECT_INIT>` marker
 in `templates/experiment.py` is replaced at scaffold time per the
-recorded `skore mode:` decision. Two forms (local vs hub),
+recorded `skore mode:` decision. Three forms (local / hub / mlflow),
 side-by-side anatomy, audit-file copy rule:
 → `references/g_skore_mode.md`.
 
@@ -410,6 +416,7 @@ report.
 - `references/scaffold_steps.md` — full prose elaboration of the
   13-step Decision flow with examples and rationale.
 - `references/g_skore_mode.md` — the G-SKORE-MODE gate in detail:
-  project init forms side-by-side, anatomy of the
-  `<SKORE_PROJECT_INIT>` substitution, switching mid-project,
-  out-of-scope notes (MLflow mode, Skore Hub account creation).
+  the three project init forms (local / hub / mlflow) side-by-side,
+  anatomy of the `<SKORE_PROJECT_INIT>` substitution, switching
+  mid-project, out-of-scope notes (running the MLflow server, Skore
+  Hub account creation).

--- a/skills/organize-ml-workspace/references/g_skore_mode.md
+++ b/skills/organize-ml-workspace/references/g_skore_mode.md
@@ -11,8 +11,8 @@ flow step 2a, and from `python-env-manager` § Tier 1 install
 
 ## Project init forms — concrete side-by-side
 
-The two forms are not "swap one word" variants; the argument shape
-changes.
+The three forms are not "swap one word" variants; the argument shape
+changes per mode.
 
 ### Local mode (default)
 
@@ -43,17 +43,39 @@ project = skore.Project(
 )
 ```
 
+### MLflow mode
+
+```python
+import skore
+
+# No login() — auth (if any) is the MLflow server's concern.
+project = skore.Project(
+    name="<experiment-name>",
+    mode="mlflow",
+    tracking_uri="<mlflow-tracking-uri>",
+)
+```
+
+`name=` is the **MLflow experiment name**; reports persist as MLflow
+model artifacts in runs created under that experiment. `tracking_uri=`
+is an **mlflow-only** kwarg — the URI of the MLflow tracking server
+(e.g. `http://127.0.0.1:5000`, `https://mlflow.acme.internal`, or a
+`file:./mlruns` / `sqlite:///mlflow.db` local backend). The
+`project.put("<key>", report)` `key` becomes the **run name**.
+Source: https://docs.skore.probabl.ai/stable/reference/api/skore.Project.html
+
 ### Diff at a glance
 
-| Concern | Local | Hub |
-|---|---|---|
-| `import` line for `login` | not needed | `from skore import login` |
-| `login(mode="hub")` call | not needed | **required, before `Project(...)`** |
-| `name=` argument | `name="<project-name>"` (bare) | `"<hub-workspace>/<project-name>"` (positional, slash-joined) |
-| `mode=` argument | `mode="local"` | `mode="hub"` |
-| `workspace=` argument | **required**: `workspace=str(PROJECT_ROOT / "reports")` | **MUST be absent** — passing it raises `TypeError` |
-| Install variant | `pixi add skore` | `pixi add "skore[hub]"` |
-| Pre-condition | none | Skore Hub account + access to `<hub-workspace>` |
+| Concern | Local | Hub | MLflow |
+|---|---|---|---|
+| `import` line for `login` | not needed | `from skore import login` | not needed |
+| `login(mode="hub")` call | not needed | **required, before `Project(...)`** | not needed |
+| `name=` argument | `name="<project-name>"` (bare) | `"<hub-workspace>/<project-name>"` (positional, slash-joined) | `name="<experiment-name>"` (MLflow experiment name) |
+| `mode=` argument | `mode="local"` | `mode="hub"` | `mode="mlflow"` |
+| `workspace=` argument | **required**: `workspace=str(PROJECT_ROOT / "reports")` | **MUST be absent** — passing it raises `TypeError` | **MUST be absent** — `tracking_uri=` is used instead |
+| `tracking_uri=` argument | not used | not used | **required**: the MLflow tracking server URI |
+| Install variant | `pixi add skore` | `pixi add "skore[hub]"` | `pixi add "skore[mlflow]"` |
+| Pre-condition | none | Skore Hub account + access to `<hub-workspace>` | reachable MLflow tracking server at `<uri>` |
 
 ## The gate — AskUserQuestion shape
 
@@ -69,6 +91,10 @@ even if the user has used skore in `local` mode in prior projects.
    - `hub` — artifacts on https://skore.probabl.ai, requires
      account + workspace access, recommended for team
      collaboration.
+   - `mlflow` — artifacts pushed to an MLflow tracking server (the
+     skore `skore[mlflow]` backend integration), recommended when
+     the team already runs MLflow or standardizes on it for
+     experiment storage.
 
    Default proposal: `local`.
 
@@ -88,11 +114,32 @@ even if the user has used skore in `local` mode in prior projects.
    part of the project name. Do not silently accept slashes — that
    produces an unparseable Project name at runtime.
 
+3. **MLflow tracking URI** (only when mode is `mlflow`). Free-form
+   string — the `tracking_uri=` passed to `skore.Project(...)`.
+   The agent **cannot** infer the server address; the user must
+   supply it. Accept the forms MLflow itself accepts:
+   - an HTTP(S) tracking server — `http://127.0.0.1:5000`,
+     `https://mlflow.acme.internal`;
+   - a database backend — `sqlite:///mlflow.db`,
+     `postgresql://…`;
+   - a local file store — `file:./mlruns` or an absolute `file:`
+     path.
+
+   If the user picks `mlflow` without knowing the URI, surface that
+   they need a running tracking server (or a local backend path)
+   before reports can be pushed — do NOT default the URI silently.
+   A bare host:port without a scheme (e.g. `localhost:5000`) should
+   be confirmed as `http://localhost:5000` rather than passed
+   verbatim.
+
 ### Free-text resolution
 
-- Explicit naming of `local` / `hub` resolves immediately.
+- Explicit naming of `local` / `hub` / `mlflow` resolves
+  immediately.
 - "use the cloud one" / "store remotely" → `hub`.
 - "store locally" / "no account" → `local`.
+- "push to mlflow" / "our mlflow server" / "track in mlflow" →
+  `mlflow` (then ask for the tracking URI).
 - Urgency phrasing ("quick" / "you pick") does NOT resolve — falls
   through to the structured ask.
 
@@ -101,31 +148,35 @@ even if the user has used skore in `local` mode in prior projects.
 The recorded `skore mode:` decision drives three downstream
 artifacts:
 
-| Downstream artifact | local-mode shape | hub-mode shape |
-|---|---|---|
-| `<SKORE_PROJECT_INIT>` in `experiments/NN_*.py` and `audit/NN_*.py` | `skore.Project(name="<project-name>", mode="local", workspace=str(PROJECT_ROOT / "reports"))` | `from skore import login; login(mode="hub"); skore.Project("<hub-workspace>/<project-name>", mode="hub")` |
-| Tier 1 skore install variant (per `python-env-manager` § Tier 1 install) | `pixi add skore` (or equivalent) | `pixi add "skore[hub]"` (or equivalent) |
-| `Workspace decisions` rows in `JOURNAL.md` | `skore mode: local` | `skore mode: hub` + `skore hub workspace: <name>` |
+| Downstream artifact | local-mode shape | hub-mode shape | mlflow-mode shape |
+|---|---|---|---|
+| `<SKORE_PROJECT_INIT>` in `experiments/NN_*.py` and `audit/NN_*.py` | `skore.Project(name="<project-name>", mode="local", workspace=str(PROJECT_ROOT / "reports"))` | `from skore import login; login(mode="hub"); skore.Project("<hub-workspace>/<project-name>", mode="hub")` | `skore.Project(name="<experiment-name>", mode="mlflow", tracking_uri="<mlflow-tracking-uri>")` |
+| Tier 1 skore install variant (per `python-env-manager` § Tier 1 install) | `pixi add skore` (or equivalent) | `pixi add "skore[hub]"` (or equivalent) | `pixi add "skore[mlflow]"` (or equivalent) |
+| `Workspace decisions` rows in `JOURNAL.md` | `skore mode: local` | `skore mode: hub` + `skore hub workspace: <name>` | `skore mode: mlflow` + `skore mlflow tracking uri: <uri>` |
 
 The `name=` argument shape **changes between modes** — local uses a
-bare name; hub uses `<hub-workspace>/<project>`. The local-mode
-`workspace=` kwarg points to a directory and is rejected by hub
-mode (`TypeError`). These are not "swap one word" differences; the
-substitution marker exists precisely because the shape changes.
+bare name; hub uses `<hub-workspace>/<project>`; mlflow uses the
+MLflow experiment name. The local-mode `workspace=` kwarg points to a
+directory and is rejected by both hub and mlflow modes; mlflow takes
+`tracking_uri=` instead. These are not "swap one word" differences;
+the substitution marker exists precisely because the shape changes.
 
 ## Persistence in `Workspace decisions`
 
-Two rows:
+Three rows (only the one matching the chosen mode carries a value;
+the other follow-up row is `n/a`):
 
 ```
-- skore mode: <local | hub> — recorded: <YYYY-MM-DD>
+- skore mode: <local | hub | mlflow> — recorded: <YYYY-MM-DD>
 - skore hub workspace: <hub-workspace-name | n/a> — recorded: <YYYY-MM-DD>
+- skore mlflow tracking uri: <mlflow-tracking-uri | n/a> — recorded: <YYYY-MM-DD>
 ```
 
-The hub-workspace row carries `n/a` when mode is local. On every
-later session, skills that need the mode read these rows first and
-skip re-asking — the standard `Workspace decisions` lookup pattern
-(see `iterate-ml-experiment` template § Status).
+The hub-workspace row carries `n/a` unless mode is `hub`; the
+mlflow-tracking-uri row carries `n/a` unless mode is `mlflow`. On
+every later session, skills that need the mode read these rows first
+and skip re-asking — the standard `Workspace decisions` lookup
+pattern (see `iterate-ml-experiment` template § Status).
 
 ## Switching mid-project
 
@@ -145,7 +196,7 @@ Procedure:
 3. Rewrite **every** `<SKORE_PROJECT_INIT>` block in `experiments/`
    AND `audit/`.
 4. Update the install variant via `python-env-manager` (plain
-   `skore` ↔ `skore[hub]`).
+   `skore` ↔ `skore[hub]` ↔ `skore[mlflow]`).
 5. Document the switch in `JOURNAL.md` History as a horizontal
    divider (same shape as goal pivots — see `iterate-ml-experiment`
    § Maintenance modes).
@@ -208,6 +259,30 @@ Note that in the hub form:
 - `login(...)` precedes `Project(...)` in the same cell so a
   single execution does both.
 
+### After substitution — mlflow mode
+
+The block is rewritten to drop `workspace=` and add the
+`tracking_uri=` recorded at G-SKORE-MODE. No `login(...)`:
+
+```python
+# %%
+project = skore.Project(
+    name="load-forecast",
+    mode="mlflow",
+    tracking_uri="http://127.0.0.1:5000",
+)
+```
+
+Note that in the mlflow form:
+
+- `workspace=` is **gone** — `tracking_uri=` replaces it.
+- `name=` is the **MLflow experiment name** (bare, no slash join).
+- no `login(...)` — authentication, if any, is the MLflow server's
+  concern, handled out-of-band (env vars / server config), not by
+  skore.
+- `project.put("<stem>", report)` creates a run named `<stem>`
+  under the experiment.
+
 ### Audit-file copy rule
 
 For `audit/<stem>.py`: the same substitution rule applies, but with
@@ -223,12 +298,18 @@ the `audit-ml-pipeline` Forbidden shortcuts row "Substituting
 
 ## Out of scope
 
-- **MLflow mode** (`skore[mlflow]` + `tracking_uri=`). A third
-  Project mode documented at
-  https://docs.skore.probabl.ai/stable/reference/api/skore.Project.html;
-  not included in this gate's options. If the user explicitly asks
-  for MLflow, surface it as a separate decision rather than adding
-  it to this gate's defaults.
+- **Running / provisioning the MLflow server.** When the user picks
+  `mlflow`, the gate captures the `tracking_uri=` but does NOT
+  stand up the tracking server, create the backing database, or
+  configure object storage. A reachable server (or a local
+  `file:`/`sqlite:` backend) at the supplied URI is the user's
+  responsibility — surface that pre-condition rather than spinning
+  one up.
+
+- **MLflow `delete`.** `skore.Project.delete(...)` is not
+  implemented for mlflow-mode projects. The read-back contract
+  (`summarize()` → `get(id)`) still holds; deletions must be done
+  through MLflow's own tooling.
 
 - **Skore Hub account creation.** The gate assumes the user has an
   account when they pick `hub`. Sign-up is a probabl.ai concern

--- a/skills/organize-ml-workspace/templates/experiment.py
+++ b/skills/organize-ml-workspace/templates/experiment.py
@@ -34,7 +34,7 @@ DATA_DIR = PROJECT_ROOT / "data"
 # stable key (the file stem). The Project init block below is filled
 # at scaffold time per the workspace's `skore mode:` decision
 # (recorded in `journal/JOURNAL.md` Status `Workspace decisions`; see
-# `organize-ml-workspace` § "G-SKORE-MODE"). Two forms:
+# `organize-ml-workspace` § "G-SKORE-MODE"). Three forms:
 #
 # - **local mode**: `skore.Project(name=..., mode="local",
 #   workspace=str(PROJECT_ROOT / "reports"))`. Reports persist to disk
@@ -45,9 +45,15 @@ DATA_DIR = PROJECT_ROOT / "data"
 #   Requires `pip install "skore[hub]"` (see `python-env-manager` §
 #   "Tier 1 install: skore variant per mode") and a Skore Hub
 #   account with access to the named hub workspace.
+# - **mlflow mode**: `skore.Project(name="<experiment-name>",
+#   mode="mlflow", tracking_uri="<mlflow-tracking-uri>")`. Reports are
+#   pushed to an MLflow tracking server as runs under the named
+#   experiment. No `login()`. Requires `pip install "skore[mlflow]"`
+#   and a reachable tracking server (or local `file:`/`sqlite:`
+#   backend) at the recorded URI.
 #
 # `<SKORE_PROJECT_INIT>` is replaced by the right form at scaffold
-# time. Do NOT keep both forms in the same file — only one is valid.
+# time. Do NOT keep multiple forms in the same file — only one is valid.
 
 # %%
 # <SKORE_PROJECT_INIT>

--- a/skills/python-api/references/skrub_interop.md
+++ b/skills/python-api/references/skrub_interop.md
@@ -105,7 +105,7 @@ candidates).
 
 The Project init form depends on the workspace's `skore mode:`
 decision (recorded in `JOURNAL.md` Status `Workspace decisions`;
-gate owned by `organize-ml-workspace` § "G-SKORE-MODE"). Two
+gate owned by `organize-ml-workspace` § "G-SKORE-MODE"). Three
 forms; pick the one matching the workspace:
 
 ```python
@@ -126,18 +126,35 @@ project = skore.Project("<hub-workspace>/load-forecast", mode="hub")
 project.put("01_baseline", report)
 ```
 
+```python
+# mlflow mode  (no login — auth is the MLflow server's concern)
+project = skore.Project(
+    name="load-forecast",            # MLflow experiment name
+    mode="mlflow",
+    tracking_uri="http://127.0.0.1:5000",  # recorded at G-SKORE-MODE
+)
+project.put("01_baseline", report)   # key = MLflow run name
+```
+
 - **Key convention**: file stem of the experiment script. Re-using
   the key in a later run overwrites the previous report — fork into
-  a new experiment file if you want both.
+  a new experiment file if you want both. (In mlflow mode the key
+  is the run name under the experiment.)
 - **Local-mode `workspace=str(PROJECT_ROOT / "reports")`** — the
   on-disk directory where the Project store lives. Created on
-  first `put`. **Not** a valid kwarg in hub mode.
+  first `put`. **Not** a valid kwarg in hub or mlflow mode.
+- **mlflow-mode `tracking_uri=`** — the MLflow tracking server URI
+  (HTTP(S) server, `sqlite:///…`, or `file:./mlruns` backend).
+  mlflow-only kwarg; no `login()`. `skore[mlflow]` extra required.
+  Note: `project.delete(...)` is not implemented for mlflow-mode
+  projects.
 - **`name=`** — short, stable, per-workspace name. Local mode uses
   it directly; hub mode uses it after `<hub-workspace>/` as in
-  `"<hub-workspace>/load-forecast"`. Set once at project
-  bootstrap inside each experiment script's `skore.Project(...)`
-  call (the agent reads the value from `experiments/01_baseline.py`
-  when needed; there is no auto-discovery script).
+  `"<hub-workspace>/load-forecast"`; mlflow mode uses it as the
+  experiment name. Set once at project bootstrap inside each
+  experiment script's `skore.Project(...)` call (the agent reads
+  the value from `experiments/01_baseline.py` when needed; there is
+  no auto-discovery script).
 
 ## Reading back later
 

--- a/skills/python-env-manager/SKILL.md
+++ b/skills/python-env-manager/SKILL.md
@@ -416,24 +416,26 @@ Per-manager footguns:
 Read `skore mode:` from `journal/JOURNAL.md` Status
 `Workspace decisions` (set by `organize-ml-workspace` §
 G-SKORE-MODE). The variant pulls in **two orthogonal axes**: mode
-(`local` vs `hub`) and package source (**conda-forge** for pixi /
-conda+mamba, **PyPI** for uv / poetry / hatch / pip+venv). PyPI
-installs need an extra `jupyter` extra; conda-forge installs
+(`local` / `hub` / `mlflow`) and package source (**conda-forge** for
+pixi / conda+mamba, **PyPI** for uv / poetry / hatch / pip+venv).
+PyPI installs need an extra `jupyter` extra; conda-forge installs
 already ship the jupyter integration.
 
 | `skore mode:` | conda-forge managers (pixi, conda / mamba) | PyPI managers (uv, poetry, hatch, pip+venv) |
 |---|---|---|
 | `local` | `pixi add skore` / `conda install -c conda-forge skore` | `uv add "skore[jupyter]"` / `poetry add "skore[jupyter]"` / `pip install "skore[jupyter]"` |
 | `hub` | `pixi add "skore[hub]"` / `conda install -c conda-forge "skore[hub]"` | `uv add "skore[hub,jupyter]"` / `poetry add "skore[hub,jupyter]"` / `pip install "skore[hub,jupyter]"` |
+| `mlflow` | `pixi add "skore[mlflow]"` / `conda install -c conda-forge "skore[mlflow]"` | `uv add "skore[mlflow,jupyter]"` / `poetry add "skore[mlflow,jupyter]"` / `pip install "skore[mlflow,jupyter]"` |
 
 If the row is absent (workspace not yet bootstrapped through
 `organize-ml-workspace`), route back to that skill's G-SKORE-MODE.
 Do not guess.
 
 **Forbidden:**
-- Silently picking `skore[hub]` "to be safe". The `[hub]` extra
-  costs ~20 MB of network deps + auth infra the local-mode user
-  didn't ask for.
+- Silently picking `skore[hub]` / `skore[mlflow]` "to be safe". The
+  `[hub]` / `[mlflow]` extras cost network deps + infra the
+  local-mode user didn't ask for; the variant follows the recorded
+  `skore mode:`, not a guess.
 - Dropping the `jupyter` extra on PyPI installs because the
   install line "looks shorter". The TableReport / `report.*`
   widgets that the audit flow and `evaluate-ml-pipeline` rely on
@@ -476,8 +478,9 @@ If detection found nothing AND the user picked `pixi` via G-ENV-MGR:
    carries `ruff`, `pytest`, `jupyterlab`, `ipykernel`; `agent`
    carries `ipython`, `pyright`.
 4. Add Tier 1 deps to `default` (per G-SKORE-MODE table above —
-   pixi is conda-forge, so `pixi add skore` or `pixi add
-   "skore[hub]"`; **no `[jupyter]` extra** on pixi).
+   pixi is conda-forge, so `pixi add skore`, `pixi add
+   "skore[hub]"`, or `pixi add "skore[mlflow]"`; **no `[jupyter]`
+   extra** on pixi).
 5. Add tabular lib (per G-TABULAR: `pandas pyarrow` or `polars`).
 6. Wire editable workspace package
    (`pixi add --pypi "<pkg> @ ."` then edit to

--- a/skills/python-env-manager/references/bootstrap.md
+++ b/skills/python-env-manager/references/bootstrap.md
@@ -76,13 +76,15 @@ The skore install variant follows G-SKORE-MODE. Pixi pulls from
 conda-forge by default, so the `[jupyter]` extra is **not** needed
 (it ships with the conda-forge package):
 
-- `skore mode: local` → `pixi add scikit-learn skrub skore`
-- `skore mode: hub`   → `pixi add scikit-learn skrub "skore[hub]"`
+- `skore mode: local`  → `pixi add scikit-learn skrub skore`
+- `skore mode: hub`    → `pixi add scikit-learn skrub "skore[hub]"`
+- `skore mode: mlflow` → `pixi add scikit-learn skrub "skore[mlflow]"`
 
 For PyPI-based managers running the analogous bootstrap (uv /
-poetry / hatch / pip+venv), substitute `skore[jupyter]` (local) or
-`skore[hub,jupyter]` (hub) — see SKILL.md § "Tier 1 install: skore
-variant per mode" for the full source-aware table.
+poetry / hatch / pip+venv), substitute `skore[jupyter]` (local),
+`skore[hub,jupyter]` (hub), or `skore[mlflow,jupyter]` (mlflow) —
+see SKILL.md § "Tier 1 install: skore variant per mode" for the
+full source-aware table.
 
 If G-SKORE-MODE hasn't fired yet at bootstrap time (rare —
 `organize-ml-workspace` fires it alongside G-PKG-NAME and

--- a/skills/python-env-manager/references/skore_variant.md
+++ b/skills/python-env-manager/references/skore_variant.md
@@ -1,8 +1,8 @@
 # Python Env Manager — skore variant per mode
 
-Why `skore` vs `skore[hub]` matters, and the procedure for switching
-modes mid-project. Cross-referenced from SKILL.md § "Tier 1 install:
-skore variant per mode".
+Why `skore` vs `skore[hub]` vs `skore[mlflow]` matters, and the
+procedure for switching modes mid-project. Cross-referenced from
+SKILL.md § "Tier 1 install: skore variant per mode".
 
 ## Why the variant matters
 
@@ -11,9 +11,15 @@ Hub mode calls `skore.login(mode="hub")` before instantiating
 `[hub]` extra; on a plain `skore` install,
 `from skore import login` raises `ImportError`.
 
+MLflow mode instantiates `skore.Project(mode="mlflow",
+tracking_uri=...)`, which drives an MLflow client under the hood;
+that client lives in the `[mlflow]` extra. On a plain `skore`
+install, constructing an mlflow-mode Project raises `ImportError` /
+`ModuleNotFoundError` for `mlflow`.
+
 Installing the wrong variant silently produces working CI for
 local-mode operations but breaks hub-mode operations at first
-`login()`.
+`login()`, or mlflow-mode operations at first `Project(...)`.
 
 ## The `[jupyter]` extra — PyPI only
 
@@ -35,19 +41,21 @@ Combined matrix:
 |---|---|---|
 | `local` | `skore` | `skore[jupyter]` |
 | `hub` | `skore[hub]` | `skore[hub,jupyter]` |
+| `mlflow` | `skore[mlflow]` | `skore[mlflow,jupyter]` |
 
-Why a single combined extra string for PyPI hub mode: PEP 508 allows
-comma-separated extras (`skore[hub,jupyter]`) and that's the form
-all four PyPI-based managers accept. Splitting into two install
-calls works too but produces two manifest rows, which is noisier
-than necessary.
+Why a single combined extra string for PyPI hub / mlflow mode: PEP
+508 allows comma-separated extras (`skore[hub,jupyter]`,
+`skore[mlflow,jupyter]`) and that's the form all four PyPI-based
+managers accept. Splitting into two install calls works too but
+produces two manifest rows, which is noisier than necessary.
 
 ## Forbidden
 
-- Silently picking `skore[hub]` "to be safe" or "because the user
-  might want hub later". The `[hub]` extra costs ~20 MB of network
-  deps + authentication infrastructure the local-mode user did not
-  ask for; the gate-based split exists to avoid that.
+- Silently picking `skore[hub]` / `skore[mlflow]` "to be safe" or
+  "because the user might want it later". The `[hub]` / `[mlflow]`
+  extras cost network deps + infrastructure (auth for hub, the
+  mlflow client for mlflow) the local-mode user did not ask for;
+  the gate-based split exists to avoid that.
 - Dropping `[jupyter]` on PyPI installs. The audit flow's report
   widgets and the TableReport viz silently degrade.
 - Adding `[jupyter]` on conda-forge installs. Redundant — the
@@ -76,13 +84,18 @@ forbidden by default" — requires explicit user confirmation):
   (conda-forge) or `"skore[hub,jupyter]"` (PyPI). The extra deps
   land additively; existing local-mode reports under `reports/`
   stay on disk but are no longer the active store.
-- **`hub` → `local`**: optionally remove the hub extra to slim the
-  env. Per-manager: `pixi remove skore && pixi add skore` (conda-
-  forge) or `uv remove skore && uv add "skore[jupyter]"` (PyPI),
-  and the equivalents for poetry / hatch / pip+venv. Existing
-  hub-mode reports stay on Skore Hub but are no longer the active
-  store from this workspace.
+- **`local` → `mlflow`** (or **`hub` → `mlflow`**): add the mlflow
+  variant — `"skore[mlflow]"` (conda-forge) or
+  `"skore[mlflow,jupyter]"` (PyPI). The prior store's reports stay
+  where they were (disk / Skore Hub) but are no longer the active
+  store.
+- **`hub` / `mlflow` → `local`**: optionally remove the extra to
+  slim the env. Per-manager: `pixi remove skore && pixi add skore`
+  (conda-forge) or `uv remove skore && uv add "skore[jupyter]"`
+  (PyPI), and the equivalents for poetry / hatch / pip+venv.
+  Existing hub-/mlflow-mode reports stay on their backend but are
+  no longer the active store from this workspace.
 
-In both directions, surface to the user that the prior store's
+In all directions, surface to the user that the prior store's
 reports are orphaned from this workspace's perspective until a
 manual migration.


### PR DESCRIPTION
closes #37 

Add MLflow in addition to local and hub mode to push the results of the Skore report.