### PR TITLE
feat: Add an EDA step before the modeling process

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ also a [Claude Code plugin marketplace](https://docs.claude.com/en/docs/claude-c
 
 | Skill | Description |
 | --- | --- |
+| [explore-ml-data](skills/explore-ml-data/SKILL.md) | Explore the dataset before designing any model. |
 | [build-ml-pipeline](skills/build-ml-pipeline/SKILL.md) | Build a machine learning pipeline from the data source to the learner, including multi-tables engineering. |
 | [evaluate-ml-pipeline](skills/evaluate-ml-pipeline/SKILL.md) | Evaluate a complex machine learning pipeline and get structured reports including metrics, plots, and diagnostics. |
 | [test-ml-pipeline](skills/test-ml-pipeline/SKILL.md) | Make sure that your machine learning pipeline is production-ready statistically and functionally. |

--- a/catalog.json
+++ b/catalog.json
@@ -2,8 +2,17 @@
   "name": "probabl-skills",
   "version": "0.3.0",
   "description": "Skills to support Machine Learning experimentation using the Python ecosystem.",
-  "catalog_hash": "88f51d552ffec83de7afa0e7b31a324c00e2708d3445108e9d137ec4c2ef5c12",
+  "catalog_hash": "9ed418853c2b09a1dec2792948af46caf6d089e7548d790617240dcead3f57a1",
   "skills": [
+    {
+      "id": "explore-ml-data",
+      "path": "skills/explore-ml-data",
+      "title": "Explore ML Data",
+      "summary": "Explore the dataset before designing any model.",
+      "category": "methodology",
+      "subcategory": null,
+      "hash": "a2f714b3ceb8203f3949500aea36b99729ba422e024d979d69d0656cf303a2e4"
+    },
     {
       "id": "build-ml-pipeline",
       "path": "skills/build-ml-pipeline",
@@ -47,7 +56,7 @@
       "summary": "Once testing and the experiment is done, audit by loading a skore report and investigate.",
       "category": "methodology",
       "subcategory": null,
-      "hash": "472b58ba5ea84a335e7cfd15bb36a060a35d069ef37724eba35315cfb82fee2e"
+      "hash": "f37c8e70fbeda01ef0e476f5622d782e5941202d3639989ae6d3daa48449dbef"
     },
     {
       "id": "iterate-ml-experiment",
@@ -56,7 +65,7 @@
       "summary": "Design, keep track of experiments and iterate on them.",
       "category": "orchestration",
       "subcategory": "dispatchers",
-      "hash": "d1a2e0e05b522df3969f97e87d8a8b43ab894f6b46aabb9958045094b9004371"
+      "hash": "1b6202dd9e434c90454ff309e005ac8549c9e48bce29185c9e9955a65e8c0b18"
     },
     {
       "id": "iterate-from-skore",
@@ -83,7 +92,7 @@
       "summary": "An organized workspace to keep track of your experiments.",
       "category": "tooling",
       "subcategory": "project-setup",
-      "hash": "8d78277795a4db48d2315e7ebeabb44a4b720d060b0770f5545c064cee0b1831"
+      "hash": "cfb545e0b48729181bfb76e52a5ec29dba9f0c5cd03f5f9095caf03c12459502"
     },
     {
       "id": "python-code-style",
@@ -92,7 +101,7 @@
       "summary": "Enforce good practices out-of-the-box for the Python ecosystem for your code.",
       "category": "tooling",
       "subcategory": "code-quality",
-      "hash": "8a4f701b03f20c246de3606149f70180095ad245660fb181cf716ab274585293"
+      "hash": "6f70c06e9ca3fb4062aedb1e878dc8c388ee9a29afa6d63bb1aa1d9e1fb33b80"
     },
     {
       "id": "python-env-manager",
@@ -101,7 +110,7 @@
       "summary": "Bootstrapping the experiment setup based on your favorite Python environment manager.",
       "category": "tooling",
       "subcategory": "project-setup",
-      "hash": "5a90b93d78b4d3d06be4c80277f520fcd5d644722dade7813584c3d5fa8567f1"
+      "hash": "9bd4bc4b773478a6359eaac0b2fc8b5db615fb34da282b5aceb4a08ac0d3b6bd"
     },
     {
       "id": "data-science-python-stack",
@@ -110,7 +119,7 @@
       "summary": "Opinionated one-library-per-job Python stack, organized into mandatory / user-choice / optional / transitive tiers.",
       "category": "reference",
       "subcategory": null,
-      "hash": "48885acffcb9fe722e715aae472f719a6009de78021cf258bdd8d9b110ee2304"
+      "hash": "9ca1072b5643403c0174134a97c5fc1ac9af1729c0ef2d954c745f12c069e5c5"
     },
     {
       "id": "python-api",
@@ -133,6 +142,7 @@
         "data-science-python-stack",
         "python-code-style",
         "python-api",
+        "explore-ml-data",
         "build-ml-pipeline",
         "evaluate-ml-pipeline",
         "test-ml-pipeline",

--- a/skills/audit-ml-pipeline/SKILL.md
+++ b/skills/audit-ml-pipeline/SKILL.md
@@ -5,9 +5,9 @@ description: >
   per experiment, aligned 1:1 with `experiments/NN_<short_name>.py` and
   `journal/NN_<short_name>.md`, that loads the experiment's skore
   report **read-only** and uses bare-last-expression cells whose
-  `__repr__` carries the audit's signal. The agent executes the audit
+  `__repr__` carries the audit's signal.   The agent executes the audit
   file via the bundled in-process runner
-  (`audit-ml-pipeline/scripts/run_audit.py` — IPython
+  (`audit-ml-pipeline/scripts/run_cells.py` — IPython
   `InteractiveShell.run_cell`), which streams a markdown digest of
   each cell's stdout + last-expression repr to stdout (optionally also
   to a file). The digest fuels narrative work (the `JOURNAL.md`
@@ -30,15 +30,18 @@ description: >
   `iterate-ml-experiment`); the experiment hasn't been run (no report
   on disk); the agent feature isn't installed (delegate to
   `python-env-manager` § "Agent feature"); the user is mining the
-  report to source the *next* experiment (`iterate-from-skore`).
+  report to source the *next* experiment (`iterate-from-skore`); the
+  user wants to explore the **raw dataset** rather than a finished
+  run's skore report (`explore-ml-data` — audit reads a report, not
+  the data).
 
   HOW TO USE: confirm the four-way stem pairing exists (`journal/NN_*.md`
   approved + `experiments/NN_*.py` exists + smoke test passed +
   report under that key in the Project), then place
   `audit/NN_<short_name>.py` from `templates/audit.py`, substituting
   the package name + the literal Project init block copied from
-  `experiments/<stem>.py`. Execute via the bundled runner: `pixi run
-  -e agent python .agents/skills/audit-ml-pipeline/scripts/run_audit.py
+  `experiments/<stem>.py`.   Execute via the bundled runner: `pixi run
+  -e agent python .agents/skills/audit-ml-pipeline/scripts/run_cells.py
   audit/<stem>.py`. **Read the Stop conditions and emit the Pre-flight
   checklist before any write or shell command.** Always invoke
   `python-api` for skore symbol signatures — never write them from
@@ -69,8 +72,8 @@ extraction step.
 | Path | Durability | Who writes it | What it holds |
 |---|---|---|---|
 | `audit/<NN>_<short_name>.py` | **Durable** (in git) | This skill, once per experiment | The bare-expression cells. Source of truth. Can be opened as a notebook in JupyterLab / VS Code for the rich HTML view |
-| `scratch/audit/<stem>/audit.md` | Ephemeral (gitignored), optional | `run_audit.py` when given a 2nd arg | Per-cell markdown digest: source + stdout + last-expression `repr`. Same content as stdout |
-| Stdout from `run_audit.py` | Captured by the bash tool | `run_audit.py` (always) | Streamed digest — the agent reads this directly from the tool output |
+| `scratch/audit/<stem>/audit.md` | Ephemeral (gitignored), optional | `run_cells.py` when given a 2nd arg | Per-cell markdown digest: source + stdout + last-expression `repr`. Same content as stdout |
+| Stdout from `run_cells.py` | Captured by the bash tool | `run_cells.py` (always) | Streamed digest — the agent reads this directly from the tool output |
 
 **Mnemonic:** `audit/` is *source* (in git); `scratch/audit/` and
 stdout are *output*. Never put the source `.py` under
@@ -211,7 +214,7 @@ Pre-flight (audit-ml-pipeline):
       Evidence: explicit grep / Read confirmation of the drafted file
 - [ ] Execution command shape confirmed:
         pixi run -e agent python \
-          .agents/skills/audit-ml-pipeline/scripts/run_audit.py \
+          .agents/skills/audit-ml-pipeline/scripts/run_cells.py \
           audit/<stem>.py [scratch/audit/<stem>/audit.md]
       (Second arg is optional — the runner always streams to stdout.)
       Evidence: command emitted in the response before running
@@ -288,7 +291,7 @@ deeper inspection here.
 
 ```bash
 pixi run -e agent python \
-  .agents/skills/audit-ml-pipeline/scripts/run_audit.py \
+  .agents/skills/audit-ml-pipeline/scripts/run_cells.py \
   audit/<stem>.py
 ```
 
@@ -392,15 +395,16 @@ Quick lookup; detailed recovery steps in `references/failure_modes.md`.
 
 - `templates/audit.py` — per-experiment audit file skeleton. Copy
   + substitute; don't rewrite from memory.
-- `scripts/run_audit.py` — the in-process cell runner. Source of
-  truth for the execution contract; don't reimplement.
+- `scripts/run_cells.py` — the in-process cell runner (generic;
+  shared with `explore-ml-data`). Source of truth for the execution
+  contract; don't reimplement or fork.
 
 ## References (load on demand)
 
 - `references/cell_anatomy.md` — concrete cell examples (right /
   wrong shapes), full 7-cell sequence, why `.frame()` matters,
   bare-expression rules.
-- `references/runner_internals.md` — what `run_audit.py` does
+- `references/runner_internals.md` — what `run_cells.py` does
   internally: parsing, IPython shell + NoOpDisplayHook, matplotlib
   Agg backend, progress-bar suppression, pandas widening, per-cell
   capture, error rendering.

--- a/skills/audit-ml-pipeline/references/failure_modes.md
+++ b/skills/audit-ml-pipeline/references/failure_modes.md
@@ -22,7 +22,7 @@ Lookup shape is wrong: `get` is by id, not by key.
 Never substitute by re-running `evaluate` + `put`. See `python-api`
 § "Lookup failure ≠ artifact missing".
 
-## `run_audit.py` exits with `ModuleNotFoundError: No module named 'IPython'`
+## `run_cells.py` exits with `ModuleNotFoundError: No module named 'IPython'`
 
 Agent feature not installed in the env the runner is invoked from.
 **Delegate to `python-env-manager` § "Agent feature" via

--- a/skills/audit-ml-pipeline/references/runner_internals.md
+++ b/skills/audit-ml-pipeline/references/runner_internals.md
@@ -1,8 +1,15 @@
 # Audit ML Pipeline — Runner internals
 
-What `scripts/run_audit.py` does internally — parsing, shell setup,
+What `scripts/run_cells.py` does internally — parsing, shell setup,
 environment fixes, per-cell capture. Cross-referenced from SKILL.md
 § "Execution contract".
+
+`run_cells.py` is a **generic** jupytext cell runner: it is owned by
+this skill but shared with `explore-ml-data` (which executes
+`data/eda.py` the same way). It is content-agnostic — it knows
+nothing about skore reports or TableReports. Keep it that way: any
+change here must serve both callers, never hard-code audit-specific
+behaviour.
 
 Load when:
 
@@ -10,12 +17,12 @@ Load when:
   ANSI escape come from? why is `Out[0]:` in the digest?).
 - The runner errors and you need to know which subsystem is at
   fault.
-- You're considering modifying `run_audit.py` — read this first.
+- You're considering modifying `run_cells.py` — read this first.
 
 ## CLI shape
 
 ```
-python run_audit.py <src.py> [<dst.md>]
+python run_cells.py <src.py> [<dst.md>]
 ```
 
 Always streams the digest to **stdout**. When `<dst.md>` is given,
@@ -151,7 +158,7 @@ cell.
   unexpected `summarize()` rows), but the runner doesn't reject
   them statically.
 
-## When you'd modify `run_audit.py`
+## When you'd modify `run_cells.py`
 
 - Adding another environment-prep step (new library that needs
   config before import).
@@ -159,4 +166,6 @@ cell.
 - Changing the output target (stdout, file, both, neither).
 
 **Always update the SKILL.md § Execution contract and this
-reference together** — they're paired documentation.
+reference together** — they're paired documentation. Because
+`explore-ml-data` shares this runner, also re-check that skill's
+§ "Execution contract" when the CLI shape or digest format changes.

--- a/skills/audit-ml-pipeline/scripts/run_cells.py
+++ b/skills/audit-ml-pipeline/scripts/run_cells.py
@@ -1,11 +1,20 @@
-"""Execute a jupytext ``# %%`` audit file and stream per-cell text to stdout.
+"""Execute a jupytext ``# %%`` file and stream per-cell text to stdout.
 
-Skill asset for ``audit-ml-pipeline``. Uses
+Generic in-process cell runner. Owned by ``audit-ml-pipeline`` and
+shared by ``explore-ml-data`` (and any future skill that executes a
+jupytext percent-format ``.py`` file cell by cell). Uses
 ``IPython.core.interactiveshell.InteractiveShell.run_cell`` to execute
 each cell in-process and streams a plain-text markdown digest to
 **stdout** (and optionally to a file when a second path argument is
 given). The agent reads the digest from the bash tool's output — no
 separate ``Read`` step required.
+
+The runner is deliberately content-agnostic: it knows nothing about
+skore reports, TableReports, or what the cells do. It parses cells,
+executes them in one shared namespace, and renders each cell's source
++ stdout + last-expression ``repr`` + errors. Callers decide what the
+cells contain (see ``audit-ml-pipeline`` § "Audit file contract" and
+``explore-ml-data`` § "EDA file contract").
 
 Why IPython, not plain Python
 -----------------------------
@@ -17,14 +26,14 @@ context).
 
 CLI
 ---
-``python run_audit.py <src.py> [<dst.md>]``
+``python run_cells.py <src.py> [<dst.md>]``
 
 Always streams the digest to stdout. When ``<dst.md>`` is supplied the
 digest is also written to that file (parent created if missing).
 
 Output shape::
 
-    # Audit: `<src.py>`
+    # Cells: `<src.py>`
 
     ## Cell 0: `# %% [markdown]`
 
@@ -224,7 +233,7 @@ def run(src_path: Path, out_path: Path | None = None) -> None:
     """
     cells = parse_cells(src_path.read_text(encoding="utf-8"))
     shell = make_shell()
-    md: list[str] = [f"# Audit: `{src_path}`\n"]
+    md: list[str] = [f"# Cells: `{src_path}`\n"]
     for i, (marker, body) in enumerate(cells):
         md.append(f"\n## Cell {i}: `{marker}`\n")
         if "[markdown]" in marker:
@@ -256,7 +265,7 @@ def run(src_path: Path, out_path: Path | None = None) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """CLI entry point: ``python run_audit.py <src.py> [<dst.md>]``.
+    """CLI entry point: ``python run_cells.py <src.py> [<dst.md>]``.
 
     Always streams the digest to stdout.  The optional second argument
     ``<dst.md>`` causes the digest to also be written to that file.

--- a/skills/data-science-python-stack/SKILL.md
+++ b/skills/data-science-python-stack/SKILL.md
@@ -451,7 +451,7 @@ the data-science deps.
 
 | Library | Role |
 |---|---|
-| `ipython` | Powers `audit-ml-pipeline/scripts/run_audit.py` via `IPython.core.interactiveshell.InteractiveShell.run_cell`. Executes the audit `# %%` cells in-process, captures plain-text repr per cell. |
+| `ipython` | Powers the shared cell runner `audit-ml-pipeline/scripts/run_cells.py` via `IPython.core.interactiveshell.InteractiveShell.run_cell`. Executes `# %%` cells in-process (audit files AND `explore-ml-data`'s `data/eda.py`), captures plain-text repr per cell. |
 | `pyright` | Powers the opencode LSP integration for Python files. Surfaces import / type / undefined-symbol diagnostics in the editor. Configured via the bundled `pyrightconfig.json` template (shipped by `python-env-manager`). |
 
 **Install + config drop: owned by `python-env-manager` § "Agent

--- a/skills/explore-ml-data/SKILL.md
+++ b/skills/explore-ml-data/SKILL.md
@@ -1,0 +1,459 @@
+---
+name: explore-ml-data
+description: >
+  Owns data understanding BEFORE any model is designed. Places and
+  executes `data/eda.py` (a jupytext `# %%` script) via the shared
+  in-process runner, reads the streamed digest, then writes a
+  persisted `data/eda.md` report (plus linked `data/eda_<table>.html`
+  skrub `TableReport` pages) and the `## Data understanding (EDA)`
+  section of `journal/JOURNAL.md`. The point is to surface the
+  dataset facts — shape, dtypes, missingness, cardinality, target
+  balance / skew, datetime / group structure, feature associations —
+  that JUSTIFY the later learner / splitter / metric decisions, so the
+  user understands *why* the modelling choices are made. Uses
+  `skrub.TableReport` for dataframe overviews and the shared runner
+  `audit-ml-pipeline/scripts/run_cells.py`. Stops at "EDA executed,
+  `data/eda.md` + HTML written, JOURNAL EDA section updated." Never
+  designs the model, never edits `src/<pkg>/`, never modifies the
+  user's raw data files.
+
+  TRIGGER — any of:
+  - `iterate-ml-experiment` § 0 bootstrap, BEFORE the baseline design
+    note — the G-EDA gate fires here (run / skip).
+  - The user asks to "explore the data", "do an EDA", "profile the
+    dataset", "what does the data look like", "understand the data".
+  - A new or changed data source needs (re-)understanding before the
+    next experiment.
+
+  SKIP when: the workspace isn't scaffolded / bootstrapped yet —
+  `iterate-ml-experiment` § 0 owns bootstrap ordering and will
+  dispatch here at the G-EDA step; don't run standalone ahead of
+  scaffolding (route to `iterate-ml-experiment` / `organize-ml-
+  workspace`); there is no data to explore yet; the user wants to
+  inspect a finished run's skore report rather than the raw dataset
+  (`audit-ml-pipeline`); the user is past data understanding and wants
+  pipeline / evaluation mechanics (`build-ml-pipeline` /
+  `evaluate-ml-pipeline`); a pure symbol lookup (`python-api`); EDA is
+  already recorded (`data/eda.md` + the JOURNAL EDA section exist) and
+  the user is not asking to refresh it.
+
+  HOW TO USE: run the Detection step (does `data/eda.md` + the JOURNAL
+  EDA section already exist?), emit the Pre-flight checklist as
+  visible text, read the Stop conditions, then place `data/eda.py`
+  from `templates/eda.py`, execute it via the shared runner, read the
+  digest, and author `data/eda.md` + the JOURNAL EDA section. Always
+  resolve skrub / pandas / polars symbols via `python-api`, never from
+  memory.
+---
+
+# Explore ML Data
+
+Understand the dataset before designing a model. One project-level
+EDA per workspace: an executable `data/eda.py`, a persisted
+`data/eda.md` narrative, rich `data/eda_<table>.html` reports, and a
+short JOURNAL section that links them. The findings feed the baseline
+design note's learner / splitter / metric choices.
+
+## Next-step pointers — where you go after this skill
+
+| You came here for… | → next |
+|---|---|
+| Bootstrap, before the first baseline | → back to `iterate-ml-experiment` § 0; the EDA findings inform the auto-drafted `01_baseline.md` |
+| User free-text ("explore the data") | → surface the findings; no further dispatch unless the user asks to model |
+| Re-understand a changed data source | → re-run, overwrite `data/eda.*`, refresh the JOURNAL EDA section |
+
+Always re-emit the Pre-flight checklist with evidence before
+declaring the turn done.
+
+## Where this sits in the loop
+
+EDA is a **bootstrap-time gate (G-EDA)** owned by this skill and
+fired by `iterate-ml-experiment` § 0 **before** the baseline design
+note. Ordering matters: the dataset facts (class balance, datetime /
+group columns, missingness, cardinality) are exactly what justifies
+the splitter (`G-CV-SPLITTER`), the metric default, and the learner
+default. Running EDA after the model is designed defeats the purpose.
+
+```
+scaffold → JOURNAL → goal from data/README.md
+   │
+   └─► G-EDA (run | skip)  ◄── this skill
+         │ run
+         └─► data/eda.py → execute → data/eda.md + HTML + JOURNAL §EDA
+   │
+   └─► auto-draft 01_baseline.md  (cites the EDA findings)
+```
+
+## Where things live — visual map
+
+Two locations are kept separate: the **raw data source** (read-only,
+may live anywhere) and the **EDA deliverables** (always under
+`<project>/data/`).
+
+| Path | Durability | Who writes it | What it holds |
+|---|---|---|---|
+| raw data source (`data/`, `raw/`, an absolute path, external) | user-owned, **READ-ONLY** | the user | The dataset. EDA reads it; never modifies it. May be anywhere — not assumed to be `data/` |
+| `data/eda.py` | **Durable** (committed) | This skill, once per workspace | The jupytext `# %%` EDA cells. Source of truth. Openable as a notebook for the rich view |
+| `data/eda.md` | **Durable** (committed) | This skill (authored from the digest) | The prose narrative: findings + **modelling implications** that the baseline note cites |
+| `data/eda_<table>.html` | **Durable** (committed) | `data/eda.py` via `TableReport.write_html(...)` | The rich, interactive skrub report per table — for the human |
+| `scratch/eda/eda.md` | Ephemeral (gitignored), optional | `run_cells.py` when given a 2nd arg | Per-cell digest the agent reads. Same content as stdout |
+| `journal/JOURNAL.md` § Data understanding (EDA) | **Durable** (committed) | This skill | 2–4 line summary + link to `data/eda.md` |
+
+**Mnemonic:** the raw data is *read-only and lives wherever the user
+keeps it*; `data/eda.py` is *source*; `data/eda.md` + the HTML are the
+*durable deliverables, always under `data/`*; `scratch/eda/` and
+stdout are the *ephemeral run digest*.
+
+## Read-only-against-raw-data contract
+
+The central rule. Surfaced as the first Stop condition below.
+
+**Allowed — this skill writes ONLY (deliverables always under
+`<project>/data/`, created if absent):**
+
+- `data/eda.py` — the EDA script (created / overwritten in place).
+- `data/eda.md` — the authored narrative.
+- `data/eda_<table>.html` — the skrub `TableReport` pages.
+- `scratch/eda/` — the ephemeral digest.
+- `journal/JOURNAL.md` § Data understanding (EDA).
+
+**Forbidden:**
+
+- Modifying, deleting, renaming, re-encoding, or "cleaning" the
+  user's raw data files — **wherever they live** (`data/`, another
+  folder, an absolute/external path). EDA **reads** them; it never
+  rewrites them. Data cleaning is the pipeline's job
+  (`build-ml-pipeline`), declared at fit time, not a one-off mutation.
+- Writing anywhere outside the five paths above — no `src/<pkg>/`
+  edits, no `reports/` writes, no new experiment files.
+- Designing the model: no `skore.evaluate(...)`, no `project.put(...)`,
+  no learner selection here. EDA *informs* those; it does not make
+  them.
+
+## Stop conditions — read before anything else
+
+- **Read-only against the user's raw data.** See § Read-only-
+  against-raw-data contract. `data/eda.py` reads the raw files
+  (wherever they live) and writes only the `data/eda.*` deliverables.
+- **Deliverables always under `<project>/data/`; the raw source is
+  separate.** Write `data/eda.py` / `data/eda.md` /
+  `data/eda_<table>.html` under `<project>/data/` (create the folder
+  if absent). The raw data the script *reads* may live anywhere
+  (`data/`, another in-repo folder, an absolute or external path) —
+  decouple the two: a `RAW = <LOAD_RAW_DATA>` source vs an `EDA_DIR`
+  output. Never assume the raw data is in `data/`.
+- **EDA precedes model design (G-EDA).** In bootstrap, the gate fires
+  **before** `journal/01_baseline.md` is drafted. It is binary:
+  **run** (place + execute `data/eda.py`, write the deliverables) or
+  **skip** (record `Status: skipped — <date>` in the JOURNAL section
+  and proceed). Do not silently bypass — fire the `AskUserQuestion`.
+  Free-text "go fast" / "quick baseline" does NOT resolve it.
+- **Agent feature required to execute.** The cell runner needs
+  `ipython`. If it is missing and the user chose **run**, STOP and
+  delegate to `python-env-manager` § "Agent feature"
+  (`G-AGENT-FEATURE`). Do NOT type `pixi add ... ipython` yourself;
+  do NOT fabricate EDA output with hand-written `print()`s. If the
+  user declines the agent feature, **fall back to the skip path**
+  (record `Status: skipped`) — never loop between run and install.
+- **Symbol from memory is forbidden.** Any `skrub` / `pandas` /
+  `polars` symbol (`TableReport`, `TableReport.json`, `write_html`,
+  `column_associations`, the tabular reader, …) must come from
+  `python-api` *this turn*. Cache hits under
+  `scratch/api/<lib>/<version>/` count; inline memory does not.
+  **`TableReport.json()`'s key names are not formally documented and
+  drift across skrub versions — confirm them via `python-api` and
+  parse defensively (`.get(...)`).**
+- **Library-agnostic — read facts off skrub, not pandas/polars.** The
+  workspace may use pandas OR polars (G-TABULAR), whose summary
+  methods differ (`select_dtypes` doesn't even exist in polars). The
+  structured facts come from `skrub` (`TableReport(...).json()`,
+  `column_associations`), which accept both. The ONLY library-
+  specific line is `RAW = <LOAD_RAW_DATA>`. Do not write
+  `df.isna()`/`df.nunique()`/`df.select_dtypes(...)` etc.
+- **`skrub.TableReport` for dataframe overviews.** Every table gets a
+  `TableReport(RAW, title=..., verbose=0)` written to
+  `data/eda_<table>.html` (the user-facing artifact) AND read via
+  `.json()` for the digest. `verbose=0` keeps progress prints out of
+  the digest.
+- **Never end a cell on a bare `TableReport`.** Outside a notebook,
+  `repr(TableReport(df))` is the useless `<TableReport: use .open()
+  to display>`. Use `report.write_html(...)` (a statement) for the
+  HTML, and end cells on **text-friendly** expressions (`RAW.shape`,
+  a `dict`/`list` built from `report.json()`,
+  `skrub.column_associations(RAW)`) so the digest carries real
+  values. Mirrors audit's `.frame()` rule.
+- **Never gitignore the whole `data/`; ask about the inputs.** The
+  deliverables live in `data/` and must stay committable, so the
+  whole `data/` folder must never be in `.gitignore`. If the raw
+  inputs should be kept out of git (large / local-only), fire an
+  `AskUserQuestion` offering to ignore **specific input patterns**
+  (e.g. `data/raw/`, `data/*.parquet`) — default: don't. Then verify
+  the deliverables are tracked (`git check-ignore data/eda.md` must
+  return nothing). Never auto-edit `.gitignore` — that is
+  `organize-ml-workspace`'s to write; surface the patch and ask.
+- **One project-level EDA.** A single `data/eda.py` covers the whole
+  dataset; multi-table data gets one `TableReport` cell per table
+  inside that one file (run the target/structure cells on the
+  target-bearing table). No `eda_v2.py`, no per-experiment EDA files,
+  not part of the four-way stem pairing. Re-understanding overwrites
+  `data/eda.py` in place.
+- **Don't design the model here.** No splitter pick, no metric pick,
+  no learner pick. Record *implications* in `data/eda.md`; the picks
+  happen in their owning gates (`G-CV-SPLITTER`, the baseline note).
+- **Harness "no clarifying questions" hints do NOT waive G-EDA or
+  G-AGENT-FEATURE.** Both fire regardless.
+- **Post-hoc audit — required before ending the turn.** Walk every
+  pre-flight row; surface unfilled Evidence cells explicitly.
+
+## Forbidden shortcuts
+
+| Shortcut | Why it's wrong |
+|---|---|
+| Design the baseline first, EDA "later if there's time" | Inverts G-EDA. The point is to justify the modelling choices *before* making them. EDA runs first in bootstrap |
+| End a cell on a bare `TableReport(df)` to "show the report" | Outside a notebook that repr is `<TableReport: use .open() to display>` — zero signal in the digest. Use `write_html(...)` + a text summary built from `report.json()` |
+| `print(...)` instead of a bare summary expression | The runner captures bare last-expressions via `result.result`; `print(...)` lands in stdout and is harder to scan. Use bare expressions |
+| Use pandas/polars methods (`df.isna()`, `df.nunique()`, `df.select_dtypes(...)`) for the summaries | Breaks on the other library (polars has no `select_dtypes`). Read the facts off `skrub` (`TableReport(...).json()`, `column_associations`) — agnostic to pandas/polars |
+| Clean / impute / drop columns in `data/eda.py` and re-save the raw file | EDA is read-only against raw data. Cleaning belongs in the pipeline (`build-ml-pipeline`), applied at fit time for train/test consistency |
+| Assume the raw data is in `data/` | The raw source may live anywhere; only the deliverables are pinned to `data/`. Set `RAW = <LOAD_RAW_DATA>` to wherever the data actually is |
+| Gitignore the whole `data/` folder | The committed deliverables (`data/eda.*`) live there. Ignore only specific input patterns, and ask the user first |
+| Run EDA without the agent feature by hand-writing the expected output | Fabricated EDA is worse than none. Missing runner → G-AGENT-FEATURE (install) or the skip path |
+| `pixi add ipython` directly from this skill | Install is owned by `python-env-manager`. This skill *requests* via G-AGENT-FEATURE |
+| Drop the authored `data/eda.md` and leave only the HTML | The `.md` carries the modelling implications the baseline note cites and the JOURNAL section links. Both are required |
+| Invent column meanings not visible in the data | Report what the data shows. Domain semantics the user didn't state go in an explicit "open questions" list, not as asserted fact |
+| Forget the JOURNAL § Data understanding update | The section is the index entry; without it later sessions can't find the EDA. It is part of "done" |
+
+## Pre-flight — emit before any write or execution
+
+```
+Pre-flight (explore-ml-data):
+- [ ] Trigger: bootstrap-G-EDA | user-request | data-changed
+      Evidence: caller + rule that matched
+- [ ] Detection: EDA already present? data/eda.md + JOURNAL §EDA
+      Evidence: ls / Glob on data/eda.md + Read JOURNAL §EDA
+                | "n/a — first EDA"
+- [ ] G-EDA resolved: run | skip
+      Evidence: AskUserQuestion id=<id>, answer=<run|skip>
+                | user free-text quote turn N
+      If skip: JOURNAL §EDA records "Status: skipped — <date>"; STOP here.
+- [ ] Tabular library known (G-TABULAR): pandas | polars
+      Evidence: JOURNAL.md Status (Workspace decisions) | AskUserQuestion
+                via data-science-python-stack
+- [ ] Raw data located (may be outside data/): <paths / loader>
+      Evidence: ls / Glob on the data location + the RAW load call placed
+                in data/eda.py | user-quoted path turn N
+- [ ] data/ not gitignored as a whole; deliverables will be tracked
+      Evidence: `git check-ignore data/eda.md` returns nothing
+                | AskUserQuestion id=<id> on ignoring specific inputs
+                | "n/a — no .gitignore yet"
+- [ ] Agent feature available (run path only):
+        `pixi run -e agent ipython -c "print(0)"` exit 0
+      Evidence: tool output | JOURNAL.md Status `agent feature: installed`
+                Missing → STOP, delegate to python-env-manager G-AGENT-FEATURE
+                (decline → fall back to skip path)
+- [ ] python-api consulted for symbols used:
+        skrub.TableReport, TableReport.write_html, TableReport.json,
+        skrub.column_associations, the tabular reader (load cell only)
+      Evidence: Read/Write scratch/api/<lib>/<version>/<topic>.md (this turn)
+                | "n/a — cache hit + Read this turn"
+- [ ] Template copy + substitution decided:
+        <pkg> → package name from src/<pkg>/
+        <LOAD_RAW_DATA> → the real loader, pointing wherever the data lives
+        <TARGET_COLUMN> → the target (from goal / data/README.md), or n/a
+        <table> → short slug per table for eda_<table>.html
+      Evidence: Read templates/eda.py this turn before Write data/eda.py
+- [ ] Execution command shape confirmed:
+        pixi run -e agent python \
+          .agents/skills/audit-ml-pipeline/scripts/run_cells.py \
+          data/eda.py [scratch/eda/eda.md]
+      Evidence: command emitted before running
+- [ ] Deliverables written: data/eda.md (prose + implications),
+        data/eda_<table>.html (≥1), JOURNAL §Data understanding
+      Evidence: Write of each | "n/a — skip path"
+- [ ] Pre-flight re-emitted with evidence before final message.
+      Evidence: this checklist appears in the end-of-turn summary.
+```
+
+## EDA file contract — overview
+
+`data/eda.py` is **jupytext percent format** (`# %%`), executed by
+the shared runner. Template: `templates/eda.py`. Full cell-by-cell
+anatomy with right / wrong shapes: → `references/cell_anatomy.md`.
+
+### Substitutions
+
+| Placeholder | Replaced with |
+|---|---|
+| `<pkg>` | The importable package name (from `src/<pkg>/`); used for `from <pkg> import PROJECT_ROOT` (only to locate `EDA_DIR = PROJECT_ROOT / "data"`) |
+| `<LOAD_RAW_DATA>` | The real load of the raw file(s), pointing wherever the data lives (in `data/`, another folder, an absolute path, or external). Uses the workspace tabular lib (pandas/polars); skrub accepts both. The one library-specific line |
+| `<TARGET_COLUMN>` | The target column name (from the goal / `data/README.md`), or remove the target cell if unsupervised / unknown |
+| `<table>` | A short slug per table for the HTML filename (`eda_<table>.html`) — for a single table use the dataset name |
+
+### Cell sequence (what each cell does)
+
+Brief outline; concrete examples → `references/cell_anatomy.md`.
+
+1. **Module docstring (markdown)** — what this file is, the
+   read-only-against-raw-data rule, raw-vs-deliverables split, how it
+   is executed.
+2. **Imports + paths (code)** — `import json`, `import skrub`,
+   `from <pkg> import PROJECT_ROOT`, `EDA_DIR = PROJECT_ROOT / "data"`
+   (+ `EDA_DIR.mkdir(parents=True, exist_ok=True)`). No pandas/polars
+   import here.
+3. **Load raw data (code, bare expression)** — `RAW = <LOAD_RAW_DATA>`
+   pointing wherever the data lives; end on `RAW.shape`.
+4. **Per-table overview (code)** — `report = skrub.TableReport(RAW,
+   title=..., verbose=0)`; `report.write_html(EDA_DIR /
+   "eda_<table>.html")`; then `summary = json.loads(report.json())`
+   and end on a `dict`/`list` of per-column dtype / null / cardinality
+   facts. One such cell per table.
+5. **Target analysis (code, bare expression)** — pick the target's
+   entry out of `summary["columns"]`; it carries value counts
+   (classification) or a distribution summary (regression). Drives the
+   metric default and whether the splitter should stratify.
+6. **Structure signals (code, bare expression)** — datetime columns
+   (from skrub's inferred dtypes, catches string dates) and high
+   unique-ratio id/group columns. Drives the `G-CV-SPLITTER` choice
+   (`TimeSeriesSplit` / `GroupKFold`).
+7. **Associations (code, bare expression)** —
+   `skrub.column_associations(RAW)` to flag strong predictors and
+   possible leakage.
+8. **End (markdown)** — reminder that the agent now authors
+   `data/eda.md` + the JOURNAL section from this digest.
+
+`write_html(...)` is load-bearing on the overview cells (the human
+artifact). `verbose=0` and the bare `report.json()`-derived
+expressions are load-bearing for a clean, library-agnostic digest.
+For multi-table data, run cells 5–7 on the target-bearing table; for
+very large data, load a row sample (see `references/cell_anatomy.md`).
+
+## Execution contract — one command
+
+```bash
+pixi run -e agent python \
+  .agents/skills/audit-ml-pipeline/scripts/run_cells.py \
+  data/eda.py
+```
+
+The runner (shared with `audit-ml-pipeline`) streams the digest to
+stdout — the agent reads it directly from the bash tool output. Pass
+a second arg `scratch/eda/eda.md` to also write the digest to a file.
+For non-pixi workspaces, swap the activation prefix per
+`python-env-manager` § "Agent feature".
+
+**This skill ships no runner of its own** — there is no
+`explore-ml-data/scripts/`. Always invoke the shared
+`audit-ml-pipeline/scripts/run_cells.py` at the path above; don't
+look for or fork a local copy.
+
+**Prerequisites for the run path:** the workspace package must be
+importable (`from <pkg> import PROJECT_ROOT` — editable install done
+during scaffold) and `skrub` installed (Tier 1). If either import
+fails, the digest shows the `ImportError`; route to
+`python-env-manager` for the missing piece rather than working around
+it.
+
+### Re-execution semantics
+
+- A changed / added data source → overwrite `data/eda.py`, re-run,
+  re-author `data/eda.md` + HTML, refresh the JOURNAL section.
+- `scratch/eda/` is overwritten on every run. The durable record is
+  `data/eda.py` + `data/eda.md` + git history.
+
+## Authoring `data/eda.md`
+
+After the run, read the digest and write `data/eda.md` from
+`templates/eda.md`. It is prose, grounded in the digest — no invented
+facts. Required sections:
+
+- **Dataset at a glance** — tables, rows × columns, target.
+- **Per-column findings** — dtypes, missingness, cardinality
+  highlights, anything surprising.
+- **Target** — balance / skew; class counts or distribution summary.
+- **Structure** — datetime ordering, groups / ids (or "none found").
+- **Associations** — strong feature↔target / feature↔feature links;
+  flag possible leakage explicitly.
+- **Modelling implications** — the payoff section. Translate findings
+  into *candidate* picks the baseline note will weigh: e.g.
+  "imbalanced target → `StratifiedKFold` + look at ROC-AUC / PR-AUC,
+  not accuracy"; "`user_id` repeats across rows → consider
+  `GroupKFold`"; "timestamp present → `TimeSeriesSplit` if forecasting".
+  These are *implications*, not decisions — the gates own the picks.
+- **Open questions** — domain ambiguities for the user to confirm.
+
+Link each `data/eda_<table>.html` from the relevant section.
+
+## JOURNAL § Data understanding (EDA)
+
+`iterate-ml-experiment`'s `JOURNAL.md` carries a top-level
+`## Data understanding (EDA)` section (placed right after `##
+Status`). This skill owns its content:
+
+```
+## Data understanding (EDA)
+
+- **Status:** done — <YYYY-MM-DD>   <!-- or: skipped — <YYYY-MM-DD> -->
+- **Summary:** <2–4 lines: dataset shape, target balance/skew, the
+  one or two findings that most shape the modelling choices>
+- **Report:** [data/eda.md](../data/eda.md)
+```
+
+Keep it to a few lines — it is an index entry, not the report. The
+detail lives in `data/eda.md`. On the **skip** path, only the
+`Status: skipped` line is required.
+
+## Dispatching in and out
+
+### Called from
+
+| Caller | When |
+|---|---|
+| `iterate-ml-experiment` § 0 bootstrap | Automatic; G-EDA fires **before** the baseline design note |
+| User free-text | "explore the data", "do an EDA", "profile the dataset" — resolves directly |
+
+### Calls into
+
+| Callee | Why |
+|---|---|
+| `python-env-manager` § Agent feature | When `ipython` is missing on the run path — G-AGENT-FEATURE |
+| `python-api` | Every skrub / pandas / polars symbol. Cache hits first |
+| `data-science-python-stack` | G-TABULAR (pandas / polars) if not yet recorded; skrub `TableReport` reference |
+| `python-code-style` | After writing `data/eda.py` — ruff format / check |
+
+## What this skill does NOT do
+
+- Design, select, or evaluate a model (`build-ml-pipeline` /
+  `evaluate-ml-pipeline` / `iterate-ml-experiment`).
+- Pick the CV splitter or metric — it only surfaces the *evidence*
+  for those picks.
+- Edit `src/<pkg>/` or the experiment / audit files.
+- Clean, transform, or re-save the user's raw data.
+- Install `ipython` / `pyright` (`python-env-manager` owns).
+- Open or write the skore Project.
+- Render commits or PRs.
+
+## Companion skills
+
+| Skill | Relationship |
+|---|---|
+| `iterate-ml-experiment` | Caller. § 0 fires G-EDA before the baseline note; the EDA findings seed the note's Method / Risks |
+| `audit-ml-pipeline` | Owns the shared cell runner `scripts/run_cells.py` this skill executes; same bare-expression discipline |
+| `organize-ml-workspace` | Workspace layout; `data/` is user-owned — this skill is the one exception that writes `data/eda.*` into it |
+| `python-env-manager` | Agent feature install (G-AGENT-FEATURE). This skill requests; that skill installs |
+| `python-api` | skrub / pandas / polars symbol lookups. Cache hits first |
+| `data-science-python-stack` | G-TABULAR; skrub `TableReport` is catalogued there |
+| `python-code-style` | ruff after writing `data/eda.py` |
+
+## Templates and assets
+
+- `templates/eda.py` — the `data/eda.py` skeleton. Copy + substitute;
+  don't rewrite from memory.
+- `templates/eda.md` — the `data/eda.md` report skeleton.
+
+The cell runner is **not** owned here — it is
+`audit-ml-pipeline/scripts/run_cells.py` (shared). Don't fork it.
+
+## References (load on demand)
+
+- `references/cell_anatomy.md` — concrete cell examples (right /
+  wrong shapes), the `TableReport` repr trap, the full cell
+  sequence, and how each finding maps to a downstream gate.

--- a/skills/explore-ml-data/references/cell_anatomy.md
+++ b/skills/explore-ml-data/references/cell_anatomy.md
@@ -1,0 +1,223 @@
+# Explore ML Data — Cell anatomy
+
+Concrete cell shapes for `data/eda.py`, the `TableReport` repr trap,
+the library-agnostic (skrub) approach, and how each finding maps to a
+downstream modelling gate. SKILL.md carries the compact cell
+sequence; load this when you are actually writing or debugging the
+cells.
+
+## Two locations, kept separate
+
+| Concern | Variable | Where | Mutable? |
+|---|---|---|---|
+| Raw data source | `RAW = <LOAD_RAW_DATA>` | anywhere — `data/`, `raw/`, an absolute path, or external | **read-only** |
+| EDA deliverables | `EDA_DIR` | always `PROJECT_ROOT / "data"` (created if missing) | written by this skill only |
+
+The raw data is **never** assumed to live in `data/`. Only the
+deliverables (`eda_<table>.html`, and `eda.md` authored by the agent)
+land in `EDA_DIR`. This is the fix for "data lives in another folder".
+
+## Library-agnostic by design — read facts off skrub
+
+The workspace's tabular library (G-TABULAR) may be pandas **or**
+polars, whose summary methods differ (`isna`/`null_count`,
+`nunique`/`n_unique`, `select_dtypes` doesn't exist in polars, …).
+Writing pandas-specific code here breaks on polars workspaces.
+
+`skrub` is the equaliser: `TableReport` and `column_associations`
+accept both libraries and return the same thing. So the structured
+facts (dtypes, missingness, cardinality, datetime inference, target
+summary) come from `report.json()`, **not** from dataframe methods.
+The only library-specific line in the whole file is
+`RAW = <LOAD_RAW_DATA>`.
+
+> **Dependency:** `TableReport.json()`'s exact keys are not formally
+> documented and can shift across skrub versions. Confirm the shape
+> via `python-api` *this turn* (probe `report.json()` on a tiny frame
+> in `scratch/`), pin a skrub floor, and parse defensively with
+> `.get(...)`. If a key you expect is absent, adapt the field name —
+> don't crash the cell. (The template uses `name`, `dtype`,
+> `null_proportion`, `nunique`, `n_rows`, `columns` — verify these.)
+
+## The `TableReport` repr trap (the load-bearing rule)
+
+`skrub.TableReport` is built to render rich HTML in a notebook. The
+shared runner is **not** a notebook — it captures each cell's last
+bare expression via `repr(result.result)`. A bare `TableReport`
+reprs to nothing useful:
+
+```python
+# WRONG — digest shows: <TableReport: use .open() to display>
+skrub.TableReport(RAW)
+```
+
+```python
+# RIGHT — write the rich HTML (statement), read facts from json()
+report = skrub.TableReport(RAW, title="customers", verbose=0)
+report.write_html(EDA_DIR / "eda_customers.html")
+summary = json.loads(report.json())
+{"n_rows": summary.get("n_rows"), "n_columns": len(summary.get("columns", []))}
+```
+
+`verbose=0` is load-bearing too: the default `verbose=1` prints
+per-column progress into the cell's `stdout:` section.
+
+## Bare expressions, not `print()`
+
+```python
+# WRONG — lands in stdout, mixed with other noise, harder to scan
+print(summary["n_rows"])
+```
+
+```python
+# RIGHT — captured in the cell's **output:** section
+{"n_rows": summary.get("n_rows")}
+```
+
+Statement-only cells (assignments, `write_html(...)`,
+`EDA_DIR.mkdir(...)`) are fine — they just produce no `output:`
+section. Put the value you want to read on the **last** line.
+
+## Cell-by-cell, with downstream mapping
+
+### Cell 2 — imports + paths
+
+```python
+import json
+
+import skrub
+
+from <pkg> import PROJECT_ROOT
+
+EDA_DIR = PROJECT_ROOT / "data"
+EDA_DIR.mkdir(parents=True, exist_ok=True)
+```
+
+`from <pkg> import PROJECT_ROOT` works because the workspace package
+is installed editable by the time bootstrap reaches EDA. No
+pandas/polars import here — only the load cell needs the tabular lib.
+
+### Cell 3 — load raw data (anywhere)
+
+```python
+RAW = pd.read_parquet(PROJECT_ROOT / "data" / "train.parquet")  # or elsewhere
+RAW.shape
+```
+
+Adapt the load to where the data actually lives — in-repo folder,
+absolute path, or external store. For multiple tables, load each into
+its own variable and repeat the overview cell (Cell 4) per table, one
+HTML file each.
+
+### Cell 4 — overview → downstream: learner / encoders
+
+```python
+report = skrub.TableReport(RAW, title="train", verbose=0)
+report.write_html(EDA_DIR / "eda_train.html")
+
+summary = json.loads(report.json())
+n_rows = summary.get("n_rows")
+overview = [
+    {
+        "column": c.get("name"),
+        "dtype": c.get("dtype"),
+        "null_pct": c.get("null_proportion"),
+        "n_unique": c.get("nunique"),
+    }
+    for c in summary.get("columns", [])
+]
+{"n_rows": n_rows, "n_columns": len(overview), "columns": overview}
+```
+
+- **High `null_pct`** → note columns that may need imputation /
+  dropping in the pipeline (not here).
+- **High `n_unique` on string columns** → high-cardinality
+  categoricals; skrub's default encoders handle these. Free-text
+  columns may want a text encoder — flag it.
+
+### Cell 5 — target → downstream: metric + stratification
+
+```python
+TARGET = "<TARGET_COLUMN>"
+next((c for c in summary.get("columns", []) if c.get("name") == TARGET), None)
+```
+
+The target's column entry carries value counts (low-cardinality →
+classification) or a distribution summary (numeric → regression), so
+one expression covers both task types — no `value_counts` blow-up on a
+continuous target.
+
+- **Imbalance** → implication: `StratifiedKFold` + ROC-AUC / PR-AUC
+  over accuracy.
+- **Heavy skew** → implication: candidate target transform; flag in
+  the baseline note's Risks.
+
+### Cell 6 — structure → downstream: `G-CV-SPLITTER`
+
+```python
+datetime_cols = [
+    c.get("name") for c in summary.get("columns", [])
+    if "date" in str(c.get("dtype", "")).lower()
+]
+unique_ratio = sorted(
+    ({"column": c.get("name"),
+      "unique_ratio": (c.get("nunique") or 0) / n_rows if n_rows else None}
+     for c in summary.get("columns", [])),
+    key=lambda r: (r["unique_ratio"] is not None, r["unique_ratio"]),
+    reverse=True,
+)
+{"datetime_cols": datetime_cols, "top_unique_ratio": unique_ratio[:10]}
+```
+
+- **Datetime column present + forecasting task** → implication:
+  `TimeSeriesSplit`. (skrub infers datetimes even from string columns,
+  so this catches dates a raw `select_dtypes` would miss.)
+- **A column whose values repeat across rows but identify an entity**
+  (`user_id`, `patient_id`) → implication: `GroupKFold` on it.
+  `unique_ratio` near 1 means a near-unique key (often a row id to
+  drop, not a group).
+
+### Cell 7 — associations → downstream: leakage check
+
+```python
+skrub.column_associations(RAW).head(20)
+```
+
+- A feature with an **implausibly perfect** association to the target
+  is a leakage flag — name it in `data/eda.md` § Associations and
+  raise it as an open question, do not silently keep it.
+
+## Multiple tables
+
+Run Cell 4 once per table (`eda_<table>.html` each). Run Cells 5–7 on
+the **target-bearing** table (the one you will model on); for the
+other tables, the Cell 4 overview is usually enough, plus a note on
+the join key. Don't try to associate columns across unjoined tables.
+
+## Large data
+
+`TableReport` computes stats over the whole frame and
+`column_associations` is roughly O(columns²). On very large datasets,
+load a row sample for the report (e.g. the first N rows or a random
+sample via the tabular lib) and say so in `data/eda.md` — the goal is
+a fast, representative read, not exhaustive stats.
+
+## What NOT to do in these cells
+
+- No imputation / dropping / re-saving of raw files (read-only).
+- No `skore.evaluate` / `project.put` (that is the experiment's job).
+- No splitter / metric / learner *decision* — only the *evidence*.
+- No pandas/polars-specific summary methods — read skrub's json.
+- No `warnings.filterwarnings(...)` — stderr in the digest is signal
+  (see `python-code-style` § Stop conditions).
+
+## From digest to deliverables
+
+After the run:
+
+1. Read the digest (stdout, or `scratch/eda/eda.md`).
+2. Author `data/eda.md` from `templates/eda.md` — every claim
+   grounded in the digest; the **Modelling implications** section is
+   the payoff the baseline note cites.
+3. Write the `journal/JOURNAL.md` § "Data understanding (EDA)" 2–4
+   line summary + link to `data/eda.md`.

--- a/skills/explore-ml-data/templates/eda.md
+++ b/skills/explore-ml-data/templates/eda.md
@@ -1,0 +1,68 @@
+<!--
+data/eda.md — persisted EDA narrative for this workspace.
+
+Owner: `explore-ml-data`. Authored from the `data/eda.py` run digest;
+every claim must be grounded in that digest — do not invent facts.
+The `journal/JOURNAL.md` § "Data understanding (EDA)" section links
+here; the baseline design note cites the "Modelling implications".
+
+Keep "implications" as *candidate* picks, not decisions — the picks
+are owned by their gates (G-CV-SPLITTER, the metric default, the
+learner default in the baseline note).
+-->
+
+# EDA — <project / dataset name>
+
+_Generated from `data/eda.py` on <YYYY-MM-DD>._
+
+## Dataset at a glance
+
+- **Tables:** <names / count>
+- **Shape:** <rows> × <cols> (per table if several)
+- **Target:** <column name + task: binary / multiclass / regression | none>
+- **Rich reports:** [eda_<table>.html](eda_<table>.html)
+
+## Per-column findings
+
+<dtypes, missingness, cardinality highlights; call out anything
+surprising — constant columns, near-duplicate columns, suspicious
+sentinel values, unexpected dtypes.>
+
+## Target
+
+<class balance (counts + proportions) for classification, or
+distribution summary + skew for regression. State imbalance / skew
+explicitly.>
+
+## Structure
+
+<datetime ordering present? group / id-like columns (with the
+unique-ratio evidence)? Or "no temporal or group structure found".>
+
+## Associations
+
+<strongest feature↔target links (candidate predictors) and notable
+feature↔feature links. **Flag any implausibly perfect association as
+a possible leakage risk** and name the column.>
+
+## Modelling implications
+
+<the payoff: translate the findings into candidate modelling choices
+the baseline note will weigh. Examples:>
+
+- <imbalanced target (X% positive) → prefer `StratifiedKFold`; report
+  ROC-AUC / PR-AUC rather than accuracy.>
+- <`<id_col>` repeats across rows → consider `GroupKFold` on it to
+  avoid leakage across folds.>
+- <`<timestamp>` present and the task is forecasting → consider
+  `TimeSeriesSplit`.>
+- <high-cardinality categoricals (`<cols>`) → skrub's default
+  encoders handle these; flag if any need text encoding.>
+- <heavy target skew → consider a target transform; flag in the
+  baseline note's Risks.>
+
+## Open questions
+
+<domain ambiguities for the user to confirm before / during the
+baseline: column meanings, sentinel values, whether a column is a
+leak, the true target definition, etc.>

--- a/skills/explore-ml-data/templates/eda.py
+++ b/skills/explore-ml-data/templates/eda.py
@@ -1,0 +1,158 @@
+# %% [markdown]
+# # EDA: <project / dataset name>
+#
+# Exploratory data analysis, run **before** any model is designed.
+# The agent executes this file via the shared in-process runner (see
+# `explore-ml-data` § "Execution contract") and reads the resulting
+# markdown digest from stdout, then authors `data/eda.md` and the
+# `journal/JOURNAL.md` § "Data understanding (EDA)" section from it.
+#
+# **Two locations, kept separate:**
+#
+# - **Raw data source** — user-owned, READ-ONLY. May live in `data/`,
+#   another in-repo folder (`raw/`, `inputs/`), an absolute path, or
+#   outside the repo. Set it at `RAW` below; it can be anything.
+# - **EDA deliverables** — always written under `EDA_DIR`
+#   (`<project>/data/`): the `eda_<table>.html` reports here, and
+#   `eda.md` authored by the agent. These are committed.
+#
+# **Hard rule (explore-ml-data § "Read-only-against-raw-data
+# contract"):** this file READS the raw data and writes ONLY the
+# `data/eda.*` deliverables. It MUST NOT clean, impute, drop, or
+# re-save the raw files — cleaning belongs in the pipeline
+# (`build-ml-pipeline`), applied at fit time.
+#
+# **Library-agnostic:** the structured facts come from `skrub`
+# (`TableReport`, `column_associations`), which work the same on
+# pandas and polars. The ONLY place a dataframe library appears is the
+# `RAW = <LOAD_RAW_DATA>` line you adapt. Do not reach for
+# pandas/polars-specific summary methods — read them off the skrub
+# report instead.
+#
+# **Bare-expression contract:** every code cell ends on a *text-
+# friendly* bare expression (a `dict`, a `list`, a `DataFrame`) so the
+# runner captures real values in the digest. NEVER end a cell on a
+# bare `skrub.TableReport(...)` — outside a notebook its repr is
+# `<TableReport: use .open() to display>`. Use `report.write_html(...)`
+# (a statement) for the rich HTML, and read facts from
+# `report.json()`.
+
+# %%
+import json
+
+import skrub
+
+from <pkg> import PROJECT_ROOT
+
+# Deliverables always land here (created if missing). This is NOT
+# necessarily where the raw data lives.
+EDA_DIR = PROJECT_ROOT / "data"
+EDA_DIR.mkdir(parents=True, exist_ok=True)
+
+# %% [markdown]
+# ## Load the raw data
+#
+# Replace `<LOAD_RAW_DATA>` with the real load of the raw file(s),
+# wherever they live. Examples:
+#
+#   RAW = pd.read_parquet(PROJECT_ROOT / "data" / "train.parquet")
+#   RAW = pd.read_csv(Path("/abs/path/or/other_folder/train.csv"))
+#   RAW = pl.read_parquet("s3://bucket/train.parquet")
+#
+# Use the workspace's tabular library (G-TABULAR: pandas or polars);
+# skrub accepts both. End the cell on `RAW.shape`. For multiple tables,
+# load each into its own variable and repeat the overview cell per
+# table.
+
+# %%
+RAW = <LOAD_RAW_DATA>
+RAW.shape
+
+# %% [markdown]
+# ## Table overview (skrub TableReport)
+#
+# `TableReport` is the user-facing artifact: write it to
+# `data/eda_<table>.html` (rich, interactive — types, distributions,
+# associations). For the agent digest, read structured per-column
+# stats off `report.json()` instead of ending on the report object.
+# `verbose=0` keeps progress prints out of the digest.
+
+# %%
+report = skrub.TableReport(RAW, title="<table>", verbose=0)
+report.write_html(EDA_DIR / "eda_<table>.html")
+
+summary = json.loads(report.json())
+n_rows = summary.get("n_rows")
+overview = [
+    {
+        "column": col.get("name"),
+        "dtype": col.get("dtype"),
+        "null_pct": col.get("null_proportion"),
+        "n_unique": col.get("nunique"),
+    }
+    for col in summary.get("columns", [])
+]
+{"n_rows": n_rows, "n_columns": len(overview), "columns": overview}
+
+# %% [markdown]
+# ## Target
+#
+# Drives the metric default and whether the splitter should stratify
+# (classification) or whether the target is skewed (regression). Read
+# the target column's entry from the same `report.json()` — it carries
+# the value counts (low-cardinality) or the distribution summary
+# (numeric), so this works for both task types without library-
+# specific code. Delete this cell if the task is unsupervised / the
+# target is unknown.
+
+# %%
+TARGET = "<TARGET_COLUMN>"
+next((col for col in summary.get("columns", []) if col.get("name") == TARGET), None)
+
+# %% [markdown]
+# ## Structure signals
+#
+# Candidate datetime columns (→ consider `TimeSeriesSplit`) and
+# high-cardinality id / group-like columns (→ consider `GroupKFold`).
+# Both come from the skrub summary: skrub infers datetime types even
+# from string columns, and the unique ratio flags id/group columns.
+# This cell only surfaces the evidence; the splitter pick is
+# `G-CV-SPLITTER`.
+
+# %%
+datetime_cols = [
+    col.get("name")
+    for col in summary.get("columns", [])
+    if "date" in str(col.get("dtype", "")).lower()
+]
+unique_ratio = sorted(
+    (
+        {
+            "column": col.get("name"),
+            "unique_ratio": (col.get("nunique") or 0) / n_rows if n_rows else None,
+        }
+        for col in summary.get("columns", [])
+    ),
+    key=lambda r: (r["unique_ratio"] is not None, r["unique_ratio"]),
+    reverse=True,
+)
+{"datetime_cols": datetime_cols, "top_unique_ratio": unique_ratio[:10]}
+
+# %% [markdown]
+# ## Associations
+#
+# `skrub.column_associations` ranks pairwise column associations
+# (library-agnostic; returns a small table). Strong feature↔target
+# links are candidate predictors; an implausibly perfect link is a
+# leakage flag to call out explicitly.
+
+# %%
+skrub.column_associations(RAW).head(20)
+
+# %% [markdown]
+# ## End of EDA
+#
+# Re-running this file overwrites `data/eda_<table>.html` and the
+# `scratch/eda/` digest. Now author `data/eda.md` (findings +
+# **modelling implications**) and the `journal/JOURNAL.md` § "Data
+# understanding (EDA)" summary from the digest above.

--- a/skills/iterate-ml-experiment/SKILL.md
+++ b/skills/iterate-ml-experiment/SKILL.md
@@ -31,7 +31,7 @@ description: >
   HOW TO USE: read `journal/JOURNAL.md` first, classify the turn via
   the **Mode picker** (table near the top), then read only the
   matching section. Sibling skills open *just-in-time* when a step
-  requires them — do not pre-read all nine at session start.
+  requires them — do not pre-read all sibling skills at session start.
   Design notes are the only artifact this skill writes; read,
   compare, and overview modes don't write.
 ---
@@ -48,6 +48,8 @@ mechanics live in sibling skills.
 session open
    │
    ├── JOURNAL.md missing / placeholder ──► § 0 Bootstrap
+   │                                          │
+   │                                          ├─► G-EDA (explore-ml-data: run | skip)
    │                                          │
    │                                          └─► design note → G-DESIGN → § 3 implement
    │
@@ -73,14 +75,16 @@ step). Do not pre-read all at session start.
 Sibling skills (just-in-time):
   - organize-ml-workspace, data-science-python-stack,
     python-env-manager, python-api, python-code-style,
-    build-ml-pipeline, evaluate-ml-pipeline, test-ml-pipeline,
-    smoke-test-ml-pipeline, iterate-from-skore / iterate-from-user
+    explore-ml-data, build-ml-pipeline, evaluate-ml-pipeline,
+    test-ml-pipeline, smoke-test-ml-pipeline,
+    iterate-from-skore / iterate-from-user
 ```
 
 Then before answering:
 
 1. **Read `journal/JOURNAL.md`.** Missing/placeholder → bootstrap (§ 0).
-   This is the canonical project digest (Status + History + Backlog).
+   This is the canonical project digest (Status, Data understanding
+   (EDA), History, Backlog).
 2. **Check `Workspace decisions` block** for pre-recorded gates
    (tabular, env_manager, package, skore_mode, cv_splitter) — a
    recorded decision skips its `AskUserQuestion`.
@@ -158,7 +162,7 @@ the **read** mode first, stop. Re-entering § 1 is a separate turn.
 | Auto-detect run finished via `reports/` mtime | § 4 is user-triggered (v1). The skill never auto-records |
 | § 4 finishes recording → declare done, skip audit dispatch | § 4 audit dispatch is part of record-outcome, not optional. The audit digest carries the headline metrics for the JOURNAL row |
 | Run experiment in same turn as G-RUN → declare done without § 4 | § 4 follows G-RUN in the same turn when the run completes successfully. Don't stop at "I ran it" — record the outcome |
-| Pre-read all nine sibling SKILL.md files at session start | Read-set tracker is not a blocking gate. Open siblings just-in-time; emit pending list but proceed |
+| Pre-read every sibling SKILL.md file at session start | Read-set tracker is not a blocking gate. Open siblings just-in-time; emit pending list but proceed |
 
 ## Pre-flight — emit before any design-note write
 
@@ -183,6 +187,10 @@ Pre-flight (iterate-ml-experiment):
 - [ ] (Bootstrap only) Config gates fired (G-PKG-NAME, G-ENV-MGR,
       G-TABULAR, G-SKORE-MODE, G-CV-SPLITTER)
       Evidence: per-gate ask id OR JOURNAL.md Status reference
+                | "n/a — iterate mode"
+- [ ] (Bootstrap only) G-EDA fired BEFORE the baseline draft
+      Evidence: explore-ml-data dispatched; answer=<run|skip>;
+                JOURNAL.md `## Data understanding (EDA)` section present
                 | "n/a — iterate mode"
 - [ ] Design note drafted (or Backlog enriched, for `skore`)
       Evidence: Write journal/<NN>_<name>.md (this turn) | "Backlog
@@ -219,12 +227,23 @@ placeholder, or has 0 History rows.
 2. **Rewrite `JOURNAL.md` from `templates/JOURNAL.md`**.
 3. **Derive the goal default from `data/README.md`** *before*
    asking. Propose one sentence; user confirms or amends.
-4. **Auto-draft `journal/01_baseline.md`** via the consultation
-   chain: learner default (`build-ml-pipeline`), splitter default
-   (`evaluate-ml-pipeline`), metric default (`python-api` on
-   skore.evaluate). Conflicts → flag in **Risks**, don't override.
-5. **User's role in bootstrap is approve or amend** — not invent.
-6. **Exit bootstrap** once the baseline is approved and recorded.
+4. **Explore the data BEFORE designing the model (G-EDA).** Dispatch
+   to `explore-ml-data`. The gate is binary (**run** / **skip**); on
+   run it executes `data/eda.py`, writes `data/eda.md` + HTML, and
+   fills the `## Data understanding (EDA)` JOURNAL section. The
+   findings (target balance / skew, datetime / group columns,
+   missingness, cardinality) feed the next step's learner / splitter /
+   metric defaults. The run path needs the agent feature (`ipython`)
+   and may trigger `G-AGENT-FEATURE` here, before the baseline; if the
+   user declines it, EDA falls back to **skip**. On skip, the JOURNAL
+   section records `Status: skipped`.
+5. **Auto-draft `journal/01_baseline.md`** via the consultation
+   chain, **informed by the EDA findings**: learner default
+   (`build-ml-pipeline`), splitter default (`evaluate-ml-pipeline`),
+   metric default (`python-api` on skore.evaluate). Conflicts with the
+   EDA findings or the goal → flag in **Risks**, don't override.
+6. **User's role in bootstrap is approve or amend** — not invent.
+7. **Exit bootstrap** once the baseline is approved and recorded.
    Audit file lands at first § 4 record-outcome.
 
 ### Bootstrap skips the sourcing menu — NOT the config gates
@@ -239,6 +258,8 @@ placeholder, or has 0 History rows.
 | `G-ENV-MGR` | Env manager | `python-env-manager` | before any install command |
 | `G-TABULAR` | Tabular library (pandas / polars) | `data-science-python-stack` | before `data.py` write |
 | `G-SKORE-MODE` | Skore Project mode (local / hub / mlflow) + hub workspace name or MLflow tracking URI | `organize-ml-workspace` | before `pyproject.toml` write |
+| `G-EDA` | Explore the data (run / skip) before the baseline is designed | `explore-ml-data` | before the `journal/01_baseline.md` draft |
+| `G-AGENT-FEATURE` | Install ipython + pyright (install / skip) | `python-env-manager` | **conditional** — when G-EDA = run and the agent feature isn't present (else first audit at § 4) |
 | `G-CV-SPLITTER` | CV family for `skore.evaluate` | `evaluate-ml-pipeline` | before `evaluate.py` write — mandatory even with empty `split_kwargs` |
 | `G-DESIGN` | User approval of `journal/01_baseline.md` | this skill | before `experiments/01_baseline.py` write |
 | `G-RUN` | "run now" vs "leave for later" | this skill | before executing the experiment script |
@@ -471,12 +492,16 @@ Pairing rule (hard, four-way): `journal/NN_<short_name>.md` ↔
 ### `JOURNAL.md` shape
 
 1. **Status** — 2-3 lines: dataset, goal, last experiment + status.
-2. **History** (chronological) — one row per experiment: stem,
+2. **Data understanding (EDA)** — short summary + link to
+   `data/eda.md`. Owned by `explore-ml-data` (written at the G-EDA
+   bootstrap step); this skill only reserves the section.
+3. **History** (chronological) — one row per experiment: stem,
    intent, status, headline, design-note link.
-3. **Backlog** (forward-looking) — indexed table; columns `#`,
+4. **Backlog** (forward-looking) — indexed table; columns `#`,
    `Item`, `Source` (`skore:<stem>` / `my-pick:<stem>` / `user`).
 
-Template: `templates/JOURNAL.md`. Don't invent sections.
+Template: `templates/JOURNAL.md`. These four are the only sanctioned
+sections — don't invent others.
 
 ### Per-experiment design-note shape
 
@@ -495,6 +520,8 @@ Template: `templates/experiment_design.md`. Sections:
 ## What this skill does NOT do
 
 - Run experiments (user / runner does that).
+- Explore / profile the dataset (`explore-ml-data` owns the G-EDA
+  step and the `## Data understanding (EDA)` section).
 - Open or query the skore Project (`evaluate-ml-pipeline` +
   `python-api`).
 - Edit `pipeline.py` / `features.py` / `data.py`
@@ -510,6 +537,7 @@ Template: `templates/experiment_design.md`. Sections:
 | Skill | Relationship |
 |---|---|
 | `organize-ml-workspace` | Scaffold + stem-pairing rule |
+| `explore-ml-data` | § 0 fires G-EDA before the baseline; the EDA findings seed the baseline note's Method / Risks and the `## Data understanding (EDA)` JOURNAL section |
 | `iterate-from-user` | User-sourced proposals (article / resource / free text) |
 | `iterate-from-skore` | Report-sourced Backlog enrichment |
 | `build-ml-pipeline` | `pipeline.py` / `features.py` / `data.py` body; reproducibility mechanics |
@@ -517,7 +545,7 @@ Template: `templates/experiment_design.md`. Sections:
 | `test-ml-pipeline` → `smoke-test-ml-pipeline` | Smoke-test body; § 4 won't flip `done` until smoke is green |
 | `audit-ml-pipeline` | § 4 dispatch; audit digest carries the headline metrics for the JOURNAL row |
 | `python-api` | Signature lookups |
-| `python-env-manager` | G-AGENT-FEATURE for audit prerequisites |
+| `python-env-manager` | G-AGENT-FEATURE for audit AND explore-ml-data (EDA) prerequisites |
 
 ## References (load on demand)
 
@@ -531,7 +559,7 @@ Template: `templates/experiment_design.md`. Sections:
 
 ## Templates
 
-- `templates/JOURNAL.md` — three-section index skeleton.
+- `templates/JOURNAL.md` — four-section index skeleton.
 - `templates/experiment_design.md` — design note with Status block.
 
 Copy, don't rewrite.

--- a/skills/iterate-ml-experiment/references/bootstrap.md
+++ b/skills/iterate-ml-experiment/references/bootstrap.md
@@ -37,10 +37,41 @@ Propose it; the user confirms or amends. **Do not prompt with a
 blank.** If no README / dataset card exists, then ask — but make
 that the exception, not the default.
 
+## Step 3.5 — Explore the data before designing the model (G-EDA)
+
+Before drafting the baseline, dispatch to `explore-ml-data`. This is
+the **G-EDA** gate — binary **run** / **skip**:
+
+- **run** → the skill places and executes `data/eda.py` via the
+  shared cell runner, writes `data/eda.md` (findings + modelling
+  implications) and `data/eda_<table>.html`, and fills the
+  `## Data understanding (EDA)` section of `JOURNAL.md`. Requires the
+  agent feature (`ipython`); if missing, `explore-ml-data` routes to
+  `python-env-manager` § Agent feature (`G-AGENT-FEATURE`) — so on the
+  run path the agent feature can get installed here, at bootstrap,
+  before the baseline. The raw data may live outside `data/`; reuse
+  the location already found when deriving the goal in Step 3 rather
+  than re-discovering it.
+- **skip** → only the `## Data understanding (EDA)` section's
+  `Status: skipped — <date>` line is written; proceed to the baseline.
+  If the user picks **run** but then **declines** the agent-feature
+  install, fall back to this skip path (record `Status: skipped`) —
+  do not loop between run and install.
+
+Why before the baseline: the dataset facts EDA surfaces (target
+balance / skew, datetime / group structure, missingness,
+cardinality, leakage flags) are exactly what justifies the learner /
+splitter / metric defaults in Step 4. Designing first and exploring
+later defeats the purpose and is the named anti-pattern.
+
+Free-text "go fast" / "quick baseline" does NOT resolve G-EDA — fire
+the `AskUserQuestion` (run / skip).
+
 ## Step 4 — Auto-draft `journal/01_baseline.md` via the consultation chain
 
 The baseline is forced, not invented — but its defaults come from
-sibling skills, not from memory:
+sibling skills, not from memory (and from the Step 3.5 EDA findings
+when EDA ran):
 
 - **Learner default**: consult `build-ml-pipeline` for what a
   "baseline" means for the data shape (tabular regression /
@@ -95,6 +126,8 @@ gate the workflow normally fires still fires.
 | `G-PKG-NAME` | `src/<pkg>/` import name | `organize-ml-workspace` | **Before** any `pyproject.toml` / `pixi.toml` creation |
 | `G-ENV-MGR` | Python env manager (`pixi`, `uv`, `poetry`, `hatch`, `conda`, `pip+venv`). The 3-feature layout (`default` / `dev` / `agent`) is enforced automatically — no scope sub-pick. | `python-env-manager` | **Before** any `pixi init` / `pixi add` / equivalent |
 | `G-TABULAR` | Tabular library (`pandas` / `polars`) + other Tier 2 contested-library picks | `data-science-python-stack` | **Before** any `Write` of `data.py` / experiment script importing the contested library |
+| `G-EDA` | Explore the data (run / skip) | `explore-ml-data` | **Before** the `journal/01_baseline.md` draft — so EDA findings can inform the learner / splitter / metric defaults |
+| `G-AGENT-FEATURE` | Install `ipython` + `pyright` (install / skip) | `python-env-manager` | **Conditional** — fires when G-EDA = run and the agent feature isn't present (the EDA cell runner needs `ipython`). Otherwise deferred to the first audit at § 4. Decline → EDA falls back to skip |
 | `G-CV-SPLITTER` | Cross-validator family for `skore.evaluate` (`KFold`, `StratifiedKFold`, `GroupKFold`, `TimeSeriesSplit`, ...) | `evaluate-ml-pipeline` | **Before** any `Write` of `src/<pkg>/evaluate.py`; mandatory even when `split_kwargs` is empty (the empty case is itself a justified pick) |
 | `G-DESIGN` | Explicit user approval of `journal/01_baseline.md` | `iterate-ml-experiment` § 3 | **Before** any `Write` of `experiments/01_baseline.py` / `src/<pkg>/*.py` content authored from the design note |
 | `G-RUN` | "Run now" vs "leave for later" once smoke tests pass | `iterate-ml-experiment` § 3 | **Before** the shell call that executes `experiments/01_baseline.py` |

--- a/skills/iterate-ml-experiment/references/maintenance_modes.md
+++ b/skills/iterate-ml-experiment/references/maintenance_modes.md
@@ -9,8 +9,9 @@ procedures.
 When the user asks "where are we?", "give me a one-pager", "what's the
 status?", "what have we tried?" — that is a **read** of
 `journal/JOURNAL.md`, not a new artifact. **`JOURNAL.md` is the
-canonical project digest** (Status + History + Backlog, three sections
-by design). Do not generate a separate summary document.
+canonical project digest** (Status, Data understanding (EDA), History,
+Backlog — four sections by design). Do not generate a separate summary
+document.
 
 - For short asks ("status?") — surface the **Status block** verbatim
   plus the last one or two History rows.

--- a/skills/iterate-ml-experiment/templates/JOURNAL.md
+++ b/skills/iterate-ml-experiment/templates/JOURNAL.md
@@ -2,12 +2,15 @@
 
 <!--
 This file is the durable index of every experiment in this workspace.
-Three sections, in order: Status, History, Backlog. Don't add new
-top-level sections; they break the contract that lets future sessions
-read this file in two seconds.
+Four sections, in order: Status, Data understanding (EDA), History,
+Backlog. Don't add OTHER top-level sections; they break the contract
+that lets future sessions read this file in two seconds.
 
-Owner: `iterate-ml-experiment` skill. Pair each `journal/NN_short_name.md`
-with `experiments/NN_short_name.py` (identical stems).
+Owner: `iterate-ml-experiment` skill (Status / History / Backlog).
+The `## Data understanding (EDA)` section is owned by `explore-ml-data`
+(written at the G-EDA bootstrap step). Pair each
+`journal/NN_short_name.md` with `experiments/NN_short_name.py`
+(identical stems).
 -->
 
 ## Status
@@ -58,6 +61,21 @@ install (ipython + pyright + pyrightconfig.json) or skipped it.
   - skore hub workspace: <hub-workspace-name | n/a> — recorded: <YYYY-MM-DD>
   - skore mlflow tracking uri: <mlflow-tracking-uri | n/a> — recorded: <YYYY-MM-DD>
   - CV splitter family: <KFold | StratifiedKFold | GroupKFold | TimeSeriesSplit | other> — recorded: <YYYY-MM-DD>
+
+## Data understanding (EDA)
+
+<!--
+Owned by `explore-ml-data`. Written at the G-EDA bootstrap step
+(before the baseline design note). Short index entry only — the full
+narrative lives in `data/eda.md`. On the skip path, keep just the
+`Status: skipped` line.
+-->
+
+- **Status:** <done | skipped> — <YYYY-MM-DD>
+- **Summary:** <2–4 lines — dataset shape, target balance/skew, and the
+  one or two findings that most shape the modelling choices. "n/a" until
+  the G-EDA gate fires.>
+- **Report:** [data/eda.md](../data/eda.md)
 
 ## History
 

--- a/skills/organize-ml-workspace/SKILL.md
+++ b/skills/organize-ml-workspace/SKILL.md
@@ -56,7 +56,7 @@ declaring the turn done.
 
 ## Sibling skills — open just-in-time
 
-Don't pre-read all nine at session start (paralysis). Open each
+Don't pre-read every sibling at session start (paralysis). Open each
 sibling SKILL.md when a step calls for it (e.g. open
 `python-env-manager` before G-ENV-MGR; open `iterate-ml-experiment`
 before handing off the design-note write). Emit this tracker once
@@ -65,8 +65,9 @@ per turn:
 ```
 Sibling skills (just-in-time):
   - data-science-python-stack, python-env-manager, python-api,
-    python-code-style, iterate-ml-experiment, build-ml-pipeline,
-    evaluate-ml-pipeline, test-ml-pipeline, smoke-test-ml-pipeline
+    python-code-style, iterate-ml-experiment, explore-ml-data,
+    build-ml-pipeline, evaluate-ml-pipeline, test-ml-pipeline,
+    smoke-test-ml-pipeline
 ```
 
 ## Stop conditions — read before anything else
@@ -267,7 +268,10 @@ Wiring per-manager: `python-env-manager` § Editable workspace.
 manager's manifest**, not in `[project.dependencies]`.
 
 **Deliberately absent:** no `data/` (user-owned), no `models/`
-(out of scope). Add later only on user request — don't pre-empt.
+(out of scope). Add later only on user request — don't pre-empt. The
+sole writer into `data/` is `explore-ml-data`, and only its own EDA
+deliverables (`data/eda.py` / `data/eda.md` / `data/eda_<table>.html`);
+the user's raw data is never modified by any skill.
 
 ## File-creation rules
 
@@ -330,7 +334,7 @@ revisiting the matching smoke test
 | 7 | Create `journal/JOURNAL.md` one-line placeholder; `iterate-ml-experiment` rewrites it | this skill |
 | 8 | Create empty `scratch/` (no README — owned by `python-api`) | this skill |
 | 9 | Create empty `reports/` | this skill |
-| 10 | Touch `.gitignore` — drop template if none; else suggest patch (always ask about `reports/`) | this skill |
+| 10 | Touch `.gitignore` — drop template if none; else suggest patch (always ask about `reports/`). **Never ignore the whole `data/`** (EDA deliverables live there); to keep raw inputs out of git, ignore specific input paths only and ask | this skill |
 | 11 | **Hand off to `python-code-style`** § Initial setup for `ruff.toml` + first pass — invoking the skill teaches NumPyDoc | this skill → python-code-style |
 | 12 | Hand back to the relevant sibling (`iterate-ml-experiment` for design note, etc.) | this skill → next caller |
 
@@ -390,6 +394,7 @@ report.
 | Skill | Relationship |
 |---|---|
 | `iterate-ml-experiment` | Owns `journal/JOURNAL.md` and per-experiment design notes. This skill places empty `journal/`; that skill fills it |
+| `explore-ml-data` | Owns the EDA deliverables inside the user's `data/` (`data/eda.py`, `data/eda.md`, `data/eda_<table>.html`) — the one exception to "this skill doesn't touch `data/`". Reads raw data, never rewrites it |
 | `build-ml-pipeline` | Body of `pipeline.py`, `features.py`, `data.py` |
 | `evaluate-ml-pipeline` | Body of `evaluate.py`; CV strategy |
 | `test-ml-pipeline` | Layout of `tests/<category>/` + stem-pairing rule |

--- a/skills/organize-ml-workspace/references/scaffold_steps.md
+++ b/skills/organize-ml-workspace/references/scaffold_steps.md
@@ -142,6 +142,19 @@ the default; ask before omitting. There is no
 `!scratch/README.md` exception — `scratch/` is gitignored in its
 entirety.
 
+**Never ignore the whole `data/` folder.** The EDA deliverables
+(`data/eda.py`, `data/eda.md`, `data/eda_*.html`, owned by
+`explore-ml-data`) live under `data/` and must stay committable; a
+`data/` (whole-folder) ignore makes them silently untracked, and a
+naive `!data/eda.md` negation does NOT re-include them when the
+parent directory is ignored. If raw **inputs** must be kept out of
+git (large / local-only), ignore specific input paths instead
+(`data/raw/`, `data/*.parquet`, …) and ask the user first. If an
+existing `.gitignore` already ignores the whole `data/`, surface the
+fix (switch to specific input patterns) rather than silently editing.
+`explore-ml-data` re-checks this at EDA time
+(`git check-ignore data/eda.md`).
+
 ## Step 11 — `ruff.toml` + first ruff pass
 
 **Hand off to `python-code-style` § "Initial setup".** That skill

--- a/skills/organize-ml-workspace/templates/.gitignore
+++ b/skills/organize-ml-workspace/templates/.gitignore
@@ -14,8 +14,14 @@ dist/
 .ruff_cache/
 .mypy_cache/
 
-# data artifacts — user owns the data/ layout; uncomment if data is local-only
-# data/
+# data artifacts — user owns the data/ layout.
+# NEVER ignore the whole data/ folder: the EDA deliverables
+# (data/eda.py, data/eda.md, data/eda_*.html, owned by explore-ml-data)
+# live there and must stay committable. To keep large/local-only raw
+# INPUTS out of git, ignore specific input paths only, e.g.:
+# data/raw/
+# data/*.parquet
+# data/*.csv
 
 # skore Project store — large/binary; commit selectively if at all
 reports/

--- a/skills/python-code-style/SKILL.md
+++ b/skills/python-code-style/SKILL.md
@@ -57,10 +57,11 @@ touched, no hook involved.
   This is the anti-infinite-loop guardrail — do not enter a third
   cycle on the same warning.
 - **Don't lint files outside the user's code.** The hook scope is
-  `src/<pkg>/`, `experiments/`, `audit/`, top-level `*.py` scripts,
-  and any package directory the user owns. Skip vendored paths,
-  generated files, and anything under `.pixi/`, `.venv/`,
-  `node_modules/`, etc.
+  `src/<pkg>/`, `experiments/`, `audit/`, `data/eda.py` (the
+  explore-ml-data EDA script), top-level `*.py` scripts, and any
+  package directory the user owns. Skip vendored paths, generated
+  files, the rest of user-owned `data/`, and anything under `.pixi/`,
+  `.venv/`, `node_modules/`, etc.
 - **Never write `ruff.toml` from memory.** The bundled
   `templates/ruff.toml` is the single source of truth — it encodes
   the per-file ignores (`experiments/**`), the numpydoc convention,
@@ -135,19 +136,20 @@ Three steps, in order:
    re-run the trio. Apply the **one-fix-per-file rule** from Stop
    conditions.
 
-If a file under `experiments/` or `audit/` has a `D100` ("missing
-module docstring") or `D103` ("missing function docstring")
-warning, that's expected for `# %%` cells; the bundled
-`ruff.toml` per-file-ignores `D100` + `D103` (and `E402`, `B018`)
-for both `experiments/**` and `audit/**`. If you're seeing them,
-the `ruff.toml` isn't loaded — check that it lives at the project
-root.
+If a file under `experiments/` or `audit/`, or the `data/eda.py`
+EDA script, has a `D100` ("missing module docstring") or `D103`
+("missing function docstring") warning, that's expected for `# %%`
+cells; the bundled `ruff.toml` per-file-ignores `D100` + `D103`
+(and `E402`, `B018`) for `experiments/**`, `audit/**`, and
+`data/eda.py`. If you're seeing them, the `ruff.toml` isn't loaded
+— check that it lives at the project root.
 
 Audit files (`audit/<NN>_<short_name>.py`, owned by
-`audit-ml-pipeline`) lint the same way as experiment files: same
+`audit-ml-pipeline`) and the EDA script (`data/eda.py`, owned by
+`explore-ml-data`) lint the same way as experiment files: same
 `# %%` cell convention, same per-file ignores, same NumPyDoc
-convention for any helper functions. After writing or editing an
-audit file, run the same trio (`ruff format` → `ruff check --fix`
+convention for any helper functions. After writing or editing one of
+these files, run the same trio (`ruff format` → `ruff check --fix`
 → `ruff check`).
 
 ## Numpydoc — the docstring convention
@@ -265,6 +267,10 @@ that the user didn't ask for.
 - **`audit-ml-pipeline`** — generates audit files at
   `audit/<NN>_<short_name>.py`. This skill's per-file ignores
   cover the audit/ path the same way they cover experiments/.
+- **`explore-ml-data`** — generates the EDA script `data/eda.py`
+  (same `# %%` cell convention). The bundled `ruff.toml`
+  per-file-ignores `data/eda.py` exactly like `audit/**`; lint it
+  with the same trio after writing it.
 - **`update-config`** — only relevant if the user explicitly asks
   for an automated lint hook later. Default is no hook.
 

--- a/skills/python-code-style/templates/ruff.toml
+++ b/skills/python-code-style/templates/ruff.toml
@@ -5,9 +5,9 @@ target-version = "py312"
 select = ["E", "F", "W", "I", "B", "UP", "D"]
 
 [lint.per-file-ignores]
-# `experiments/` and `audit/` carry jupytext-style `# %%` cell scripts.
-# The cell convention legitimately violates a few rules that are correct
-# for regular Python:
+# `experiments/`, `audit/`, and the EDA script `data/eda.py` carry
+# jupytext-style `# %%` cell scripts. The cell convention legitimately
+# violates a few rules that are correct for regular Python:
 #   E402  imports not at top of file — cells interleave imports + code
 #   B018  useless bare expression — bare expressions are the cell's output
 #   D100  missing module docstring — module-level docstring is the
@@ -16,6 +16,10 @@ select = ["E", "F", "W", "I", "B", "UP", "D"]
 #         named functions; when they do, the design-note is the doc
 "experiments/**" = ["E402", "B018", "D100", "D103"]
 "audit/**" = ["E402", "B018", "D100", "D103"]
+# `data/eda.py` is the explore-ml-data EDA cell script (one per workspace);
+# same convention, same ignores. The rest of data/ is user-owned and not
+# linted by this stack.
+"data/eda.py" = ["E402", "B018", "D100", "D103"]
 
 [lint.pydocstyle]
 convention = "numpy"

--- a/skills/python-env-manager/SKILL.md
+++ b/skills/python-env-manager/SKILL.md
@@ -233,15 +233,20 @@ doesn't index it because `lsp` doesn't compose `<X>`. User sees
 
 ### `G-AGENT-FEATURE` — install ipython + pyright
 
-**Fires when**: an agent-only consumer (currently `audit-ml-pipeline`)
-needs `ipython` / `pyright` and the manifest doesn't expose them.
+**Fires when**: an agent-only consumer (`audit-ml-pipeline` for audit
+files, or `explore-ml-data` for `data/eda.py`) needs `ipython` /
+`pyright` and the manifest doesn't expose them. With `explore-ml-data`
+this can fire as early as **bootstrap** (the G-EDA run path, before
+the baseline), not only at the first audit.
 
 **AskUserQuestion (binary)**: `install` | `skip`.
 - `install` → run the bundled per-manager script (see § "Agent
-  feature install"). Recommended default for any workspace using
-  the audit flow.
-- `skip` → block the calling skill; surface "audit step unavailable
-  until the agent feature is installed". No silent degradation.
+  feature install"). Recommended default for any workspace using the
+  audit or EDA flow.
+- `skip` → block the calling skill; surface "audit / EDA step
+  unavailable until the agent feature is installed". No silent
+  degradation. (`explore-ml-data` then falls back to its EDA-skip
+  path; `audit-ml-pipeline` blocks.)
 
 **Persists**: `agent feature: <installed | skipped> — recorded: <date>`.
 
@@ -502,7 +507,7 @@ flows, pixi-version compatibility notes:
 |---|---|
 | `data-science-python-stack` | Owns *what* to install; this skill turns it into a command |
 | `organize-ml-workspace` | Scaffold hands off here for editable install; G-TABULAR / G-SKORE-MODE feed this skill's bootstrap |
-| `audit-ml-pipeline` | G-AGENT-FEATURE fires from there |
+| `audit-ml-pipeline` / `explore-ml-data` | G-AGENT-FEATURE fires from there (audit files; `data/eda.py`) |
 | `build-ml-pipeline` / `evaluate-ml-pipeline` | Missing-dep Stop conditions redirect here |
 | `iterate-ml-experiment` | Owns the `Workspace decisions` block this skill reads / writes |
 

--- a/skills/python-env-manager/references/agent_feature_anatomy.md
+++ b/skills/python-env-manager/references/agent_feature_anatomy.md
@@ -9,10 +9,11 @@ when debugging a failed install.
 
 A project-scoped install of two agent-only tools plus a config:
 
-- **`ipython`** — powers the in-process cell runner at
-  `audit-ml-pipeline/scripts/run_audit.py` via
-  `InteractiveShell.run_cell`. No kernel registration, no
-  notebook conversion.
+- **`ipython`** — powers the shared in-process cell runner at
+  `audit-ml-pipeline/scripts/run_cells.py` via
+  `InteractiveShell.run_cell`. Used by `audit-ml-pipeline` (audit
+  files) and `explore-ml-data` (`data/eda.py`). No kernel
+  registration, no notebook conversion.
 - **`pyright`** — powers the opencode LSP integration for Python
   files. Surfaces import / type / undefined-symbol diagnostics in
   the editor. Configured via the bundled `pyrightconfig.json`
@@ -80,41 +81,45 @@ silent failure mode the script catches.
 
 Per-manager footgun catalogue: `references/per_manager_footguns.md`.
 
-## Post-install: how to invoke the audit runner
+## Post-install: how to invoke the shared cell runner
+
+The same runner executes both `audit/<stem>.py` (audit-ml-pipeline)
+and `data/eda.py` (explore-ml-data) — swap the file argument. The
+examples below show an audit file; for EDA pass `data/eda.py`.
 
 ```bash
 # pixi
 pixi run -e agent python \
-  .agents/skills/audit-ml-pipeline/scripts/run_audit.py \
+  .agents/skills/audit-ml-pipeline/scripts/run_cells.py \
   audit/<stem>.py
 
 # uv
 uv run --group agent python \
-  .agents/skills/audit-ml-pipeline/scripts/run_audit.py \
+  .agents/skills/audit-ml-pipeline/scripts/run_cells.py \
   audit/<stem>.py
 
 # poetry
 poetry run python \
-  .agents/skills/audit-ml-pipeline/scripts/run_audit.py \
+  .agents/skills/audit-ml-pipeline/scripts/run_cells.py \
   audit/<stem>.py
 
 # hatch
 hatch run agent:python \
-  .agents/skills/audit-ml-pipeline/scripts/run_audit.py \
+  .agents/skills/audit-ml-pipeline/scripts/run_cells.py \
   audit/<stem>.py
 
 # conda
 conda run -n <project>-agent python \
-  .agents/skills/audit-ml-pipeline/scripts/run_audit.py \
+  .agents/skills/audit-ml-pipeline/scripts/run_cells.py \
   audit/<stem>.py
 
 # pip + venv
 .venv-agent/bin/python \
-  .agents/skills/audit-ml-pipeline/scripts/run_audit.py \
+  .agents/skills/audit-ml-pipeline/scripts/run_cells.py \
   audit/<stem>.py
 ```
 
-The runner now streams the digest to stdout by default. Pass a
+The runner streams the digest to stdout by default. Pass a
 second arg `<dst.md>` to also write to a file.
 
 ## `pyrightconfig.json` — bundled template


### PR DESCRIPTION
closes #38 

Create a specific skills that should handle and persist a small EDA steps for the user to audit and the agent to start model.