### PR TITLE
chore: Improve readibility and consistency of templates

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -2,7 +2,7 @@
   "name": "probabl-skills",
   "version": "0.3.0",
   "description": "Skills to support Machine Learning experimentation using the Python ecosystem.",
-  "catalog_hash": "9ed418853c2b09a1dec2792948af46caf6d089e7548d790617240dcead3f57a1",
+  "catalog_hash": "eb1518487b30caf646ae5eee771e2362a4fe059848fc9723e2a717c3340e39f4",
   "skills": [
     {
       "id": "explore-ml-data",
@@ -11,7 +11,7 @@
       "summary": "Explore the dataset before designing any model.",
       "category": "methodology",
       "subcategory": null,
-      "hash": "a2f714b3ceb8203f3949500aea36b99729ba422e024d979d69d0656cf303a2e4"
+      "hash": "60fa149bf056699ec7f7608dd9ee95cce30c2c6689b579a3da58d857fa900064"
     },
     {
       "id": "build-ml-pipeline",
@@ -20,7 +20,7 @@
       "summary": "Build a machine learning pipeline from the data source to the learner, including multi-tables engineering.",
       "category": "methodology",
       "subcategory": null,
-      "hash": "6343975810344278267d3a8a27b8c27723f840c070dab730765f8c249e4eec45"
+      "hash": "64f90108710685767ddc0a515903ca6efa909e621070f8a74452a5e014a8ae77"
     },
     {
       "id": "evaluate-ml-pipeline",
@@ -29,7 +29,7 @@
       "summary": "Evaluate a complex machine learning pipeline and get structured reports including metrics, plots, and diagnostics.",
       "category": "methodology",
       "subcategory": null,
-      "hash": "729ee97bf5d4eb4548ec316cfe7294f46acbf4e4aa5f33682fff00657c3c1f3a"
+      "hash": "ee32d9289b92505e2c345042074d8b685cfeb35af606c1097ce4ff8a6b65bd28"
     },
     {
       "id": "test-ml-pipeline",
@@ -56,7 +56,7 @@
       "summary": "Once testing and the experiment is done, audit by loading a skore report and investigate.",
       "category": "methodology",
       "subcategory": null,
-      "hash": "f37c8e70fbeda01ef0e476f5622d782e5941202d3639989ae6d3daa48449dbef"
+      "hash": "d48c089c0c5b77c667ffc989c3989c01c82f7e51667fad895e31b0a045e16a87"
     },
     {
       "id": "iterate-ml-experiment",
@@ -65,7 +65,7 @@
       "summary": "Design, keep track of experiments and iterate on them.",
       "category": "orchestration",
       "subcategory": "dispatchers",
-      "hash": "1b6202dd9e434c90454ff309e005ac8549c9e48bce29185c9e9955a65e8c0b18"
+      "hash": "bc85d4588d98347687bb0a10f7d785a5896808cf3d66143cb0689a5c730501e5"
     },
     {
       "id": "iterate-from-skore",
@@ -92,7 +92,7 @@
       "summary": "An organized workspace to keep track of your experiments.",
       "category": "tooling",
       "subcategory": "project-setup",
-      "hash": "cfb545e0b48729181bfb76e52a5ec29dba9f0c5cd03f5f9095caf03c12459502"
+      "hash": "de5c6509da7b076aae74249c2685b6be22e1a33b98965f1d8c41f2c6f07fa7c4"
     },
     {
       "id": "python-code-style",
@@ -101,7 +101,7 @@
       "summary": "Enforce good practices out-of-the-box for the Python ecosystem for your code.",
       "category": "tooling",
       "subcategory": "code-quality",
-      "hash": "6f70c06e9ca3fb4062aedb1e878dc8c388ee9a29afa6d63bb1aa1d9e1fb33b80"
+      "hash": "203f9d9a5858be0eaaed6df0f7247d52d715758011acf827aa134516572b440a"
     },
     {
       "id": "python-env-manager",
@@ -110,7 +110,7 @@
       "summary": "Bootstrapping the experiment setup based on your favorite Python environment manager.",
       "category": "tooling",
       "subcategory": "project-setup",
-      "hash": "9bd4bc4b773478a6359eaac0b2fc8b5db615fb34da282b5aceb4a08ac0d3b6bd"
+      "hash": "bf03a8c6fa4d5920d64e03678e62cda74dd3c20198b804402a814bbc4c77c645"
     },
     {
       "id": "data-science-python-stack",
@@ -119,7 +119,7 @@
       "summary": "Opinionated one-library-per-job Python stack, organized into mandatory / user-choice / optional / transitive tiers.",
       "category": "reference",
       "subcategory": null,
-      "hash": "9ca1072b5643403c0174134a97c5fc1ac9af1729c0ef2d954c745f12c069e5c5"
+      "hash": "c98079d37ccec0a69bba4105673d2da6017c48e460b843fa8faca31928ccec24"
     },
     {
       "id": "python-api",
@@ -128,7 +128,7 @@
       "summary": "Discover the public API of any installed Python package to make agent find their way without bothering your workspace.",
       "category": "reference",
       "subcategory": null,
-      "hash": "8f82b9c88f898657a833f683340da63ec152a4ef3b538b0c7253ba5fdf67df99"
+      "hash": "811ffe54214f2e524efa5cb71f01adefaef01d95be916762969c0d62a2a80ea4"
     }
   ],
   "workflows": [

--- a/skills/audit-ml-pipeline/SKILL.md
+++ b/skills/audit-ml-pipeline/SKILL.md
@@ -348,7 +348,7 @@ Identical stems, 1:1. By the time the experiment shows `done` in
 |---|---|
 | `python-api` | Every skore symbol (`Project`, `project.summarize`, `project.get`, `report.checks.summarize`, `report.metrics.summarize`, `.frame()`). Cache hits first |
 | `python-env-manager` § Agent feature | When `ipython` / `pyright` are missing — G-AGENT-FEATURE gate |
-| `python-code-style` | After writing / editing `audit/<stem>.py` — bundled `ruff.toml` carries `audit/**` per-file ignores |
+| `python-code-style` | After writing / editing `audit/<stem>.py` — bundled `ruff.toml` carries `audit/**` per-file ignores; also contextualizes the header to name the audited experiment and strips workflow/process prose |
 
 ## Failure modes and recovery
 

--- a/skills/audit-ml-pipeline/templates/audit.py
+++ b/skills/audit-ml-pipeline/templates/audit.py
@@ -1,23 +1,7 @@
 # %% [markdown]
-# # Audit: experiments/<NN>_<short_name>.py
+# # Audit — <NN>_<short_name>: <what this experiment tested>
 #
-# Read-only narrative of this experiment's skore report. The agent
-# executes this file via the bundled in-process runner (see
-# `audit-ml-pipeline` § "Execution contract") and reads the resulting
-# markdown digest from stdout.
-#
-# **Hard rule (audit-ml-pipeline § "Read-only against the skore
-# Project"):** this file MUST NOT call `skore.evaluate(...)` or
-# `project.put(...)`. Only `project.summarize()`, `project.get(id)`,
-# and `report.*` accessors are allowed. Re-running evaluate / put
-# from an audit file lands a duplicate row under the same key and
-# pollutes `project.summarize()`.
-#
-# **Bare-expression contract:** each cell ends with a bare
-# expression so the executed notebook captures its auto-displayed
-# repr. Do not wrap in `print(repr(...))` — that loses rich repr
-# (`_repr_html_`, plot mime types) and clutters the human-reading
-# view.
+# Read-only review of the stored report below: its checks and metrics.
 
 # %%
 import skore
@@ -27,20 +11,9 @@ from <pkg> import PROJECT_ROOT
 # %% [markdown]
 # ## Open the project
 #
-# Same Project init form as `experiments/<NN>_<short_name>.py` — the
-# `<SKORE_PROJECT_INIT>` marker below is filled at scaffold time per
-# the workspace's `skore mode:` decision (see `organize-ml-workspace`
-# § "G-SKORE-MODE" and `audit-ml-pipeline` § "Audit file contract").
-# Two forms (only one is used per workspace):
-#
-# - **local mode**: `skore.Project(name=..., mode="local",
-#   workspace=str(PROJECT_ROOT / "reports"))`.
-# - **hub mode**: `skore.login(mode="hub")` first, then
-#   `skore.Project("<hub-workspace>/<project-name>", mode="hub")`.
-#
-# Read the form from `experiments/<NN>_<short_name>.py` — never retype
-# from memory; the audit must open the exact same Project the
-# experiment wrote to.
+# Open the same project the experiment wrote to. The init block below
+# must match `experiments/<NN>_<short_name>.py` exactly — copy it from
+# there rather than retyping it.
 
 # %%
 # <SKORE_PROJECT_INIT>
@@ -95,12 +68,8 @@ report
 #
 # `report.checks.summarize().frame()` returns a DataFrame whose rows
 # each carry a `code` (e.g. `SKD003`), a `severity` (`passed` /
-# `issue` / `tip`), and a `documentation_url`. The
-# `documentation_url` is the actionable mitigation — every check
-# that surfaces here is documented on the skore docs site, and the
-# linked page describes what the check tests **and what to try
-# next**. `iterate-from-skore` reads this section and follows the
-# URLs to draft Backlog rows.
+# `issue` / `tip`), and a `documentation_url` — the linked page
+# describes what the check tests and what to try next.
 #
 # Available on `EstimatorReport` and `CrossValidationReport` in
 # skore ≥ 0.18. Mute a noisy check via
@@ -124,9 +93,8 @@ report.checks.summarize().frame()
 #
 # Same accessor on both `EstimatorReport` and
 # `CrossValidationReport`; the latter additionally reports mean ±
-# std across folds. This section is the headline reading; it does
-# not drive Backlog rows on its own — actionable findings come
-# from the checks section above.
+# std across folds. This is the headline reading; the actionable
+# findings come from the checks section above.
 
 # %%
 report.metrics.summarize().frame()
@@ -134,8 +102,6 @@ report.metrics.summarize().frame()
 # %% [markdown]
 # ## End of audit
 #
-# Re-running this audit file overwrites
-# `scratch/audit/<NN>_<short_name>/`. The source
-# `audit/<NN>_<short_name>.py` is the durable record; the digest
-# at `scratch/audit/<NN>_<short_name>/audit.md` is the canonical
-# input to `iterate-from-skore`.
+# This file is the durable record of how the experiment's report was
+# reviewed; re-run it any time to refresh the checks and metrics
+# above.

--- a/skills/build-ml-pipeline/SKILL.md
+++ b/skills/build-ml-pipeline/SKILL.md
@@ -71,7 +71,7 @@ Read these once; they're referenced throughout.
 
 | You came here for… | → next |
 |---|---|
-| Declared pipeline → CV strategy | → `evaluate-ml-pipeline` § G-CV-SPLITTER |
+| Declared pipeline → CV strategy | → `evaluate-ml-pipeline` (the `G-CV-SPLITTER` gate, rule 3) |
 | Declared pipeline → smoke test | → `test-ml-pipeline` → `smoke-test-ml-pipeline` |
 | Symbol lookup mid-declaration | → `python-api` (Shape 1 / 1b / 3) |
 | Missing skrub/sklearn import | → `python-env-manager` § install |

--- a/skills/data-science-python-stack/SKILL.md
+++ b/skills/data-science-python-stack/SKILL.md
@@ -251,7 +251,9 @@ changes.
   mutually exclusive modes: `local` (artifacts on disk; no extra
   deps), `hub` (artifacts on Skore Hub; requires `skore[hub]`
   extra + `skore.login()` before first use), `mlflow` (artifacts
-  in an MLflow tracking server; requires `skore[mlflow]` extra).
+  in an MLflow tracking server; requires the `skore[mlflow]` extra
+  **plus an explicit `mlflow>=3` pin** — `skore[mlflow]` alone can
+  resolve an unsupported mlflow 2.x).
   The choice is a workspace-level decision owned by
   `organize-ml-workspace` § "G-SKORE-MODE" — fired at scaffold
   alongside G-PKG-NAME / G-TABULAR / G-ENV-MGR. `python-env-manager`

--- a/skills/data-science-python-stack/references/mlflow.md
+++ b/skills/data-science-python-stack/references/mlflow.md
@@ -25,7 +25,9 @@ reporting is owned by `skore` reports.
   `skore.Project(mode="mlflow", tracking_uri=...)` (the
   `skore[mlflow]` backend) and keep calling `project.put(...)`. The
   mode is picked at `organize-ml-workspace` § "G-SKORE-MODE"; you
-  still never call the raw `mlflow.log_*` API yourself.
+  still never call the raw `mlflow.log_*` API yourself. Install with an
+  explicit `mlflow>=3` pin (`skore[mlflow]` alone can resolve mlflow
+  2.x, which the backend doesn't support).
 - You only need to evaluate a model and produce a report → use
   `skore`'s `EstimatorReport` / `CrossValidationReport` /
   `ComparisonReport`.

--- a/skills/evaluate-ml-pipeline/SKILL.md
+++ b/skills/evaluate-ml-pipeline/SKILL.md
@@ -57,9 +57,14 @@ read the report. The pipeline declaration is out of scope (see
   `ComparisonReport`) and any sklearn splitter name must come from a
   `Skill(python-api)` or `Skill(python-api)` call **in this turn**.
   "I remember `KFold(n_splits=5)`" is not acceptable.
-- **Splitter choice is data-driven, not default-driven.** Pick from
-  the `split_kwargs` content at the X marker via the table in rule 3
-  — never reach for `KFold(5)` or `StratifiedKFold` out of habit. If
+- **Splitter choice is data-driven, not default-driven
+  (`G-CV-SPLITTER`).** This is the **G-CV-SPLITTER** gate — owned by
+  this skill, fired during `iterate-ml-experiment` § 3 (the build →
+  evaluate → test chain, **after** the design note is approved at
+  G-DESIGN), before `src/<pkg>/evaluate.py` is written. The splitter
+  is NOT pre-committed in the design note. Pick from the
+  `split_kwargs` content at the X marker via the table in rule 3 —
+  never reach for `KFold(5)` or `StratifiedKFold` out of habit. If
   `split_kwargs` is empty *and* you cannot rule out group / temporal
   structure, return to `build-ml-pipeline` and ask before defaulting.
 - **No `Stratified*` for class imbalance.** It compresses across-fold
@@ -127,7 +132,7 @@ read the report. The pipeline declaration is out of scope (see
   mandatory `AskUserQuestion` in this stack —
   `python-env-manager` § "Where does the package belong?",
   `data-science-python-stack` § Tier 2 (pandas vs polars),
-  `iterate-ml-experiment` § 1 (sourcing menu), `iterate-from-user`
+  `iterate-ml-experiment` § 2 (sourcing menu), `iterate-from-user`
   § "The entry-point AskUserQuestion". When in doubt: the user's
   approval is the gate, not the harness's instruction text.
 
@@ -235,7 +240,8 @@ Pre-flight (evaluate-ml-pipeline):
    API details to `python-api`.
 
 3. **Pick the cross-validator from the structural facts of the data
-   — not by default.** The data tells you what splitter is correct.
+   — not by default (the `G-CV-SPLITTER` gate).** The data tells you
+   what splitter is correct.
    The structural facts arrive at the X marker through
    `split_kwargs` (set by `build-ml-pipeline` at declaration time).
    Mapping rules:

--- a/skills/explore-ml-data/SKILL.md
+++ b/skills/explore-ml-data/SKILL.md
@@ -417,7 +417,7 @@ detail lives in `data/eda.md`. On the **skip** path, only the
 | `python-env-manager` § Agent feature | When `ipython` is missing on the run path — G-AGENT-FEATURE |
 | `python-api` | Every skrub / pandas / polars symbol. Cache hits first |
 | `data-science-python-stack` | G-TABULAR (pandas / polars) if not yet recorded; skrub `TableReport` reference |
-| `python-code-style` | After writing `data/eda.py` — ruff format / check |
+| `python-code-style` | After writing `data/eda.py` — ruff format / check + contextualize the comments to this dataset (strip any leftover workflow/process prose) |
 
 ## What this skill does NOT do
 

--- a/skills/explore-ml-data/templates/eda.md
+++ b/skills/explore-ml-data/templates/eda.md
@@ -1,14 +1,9 @@
 <!--
-data/eda.md — persisted EDA narrative for this workspace.
-
-Owner: `explore-ml-data`. Authored from the `data/eda.py` run digest;
-every claim must be grounded in that digest — do not invent facts.
-The `journal/JOURNAL.md` § "Data understanding (EDA)" section links
-here; the baseline design note cites the "Modelling implications".
-
-Keep "implications" as *candidate* picks, not decisions — the picks
-are owned by their gates (G-CV-SPLITTER, the metric default, the
-learner default in the baseline note).
+Exploratory data analysis summary for this workspace, written from
+the data/eda.py run. Ground every claim in what the run actually
+showed — do not invent facts. Keep "Modelling implications" as
+candidate suggestions to weigh when designing the model, not final
+decisions.
 -->
 
 # EDA — <project / dataset name>
@@ -48,7 +43,7 @@ a possible leakage risk** and name the column.>
 ## Modelling implications
 
 <the payoff: translate the findings into candidate modelling choices
-the baseline note will weigh. Examples:>
+to weigh when designing the model. Examples:>
 
 - <imbalanced target (X% positive) → prefer `StratifiedKFold`; report
   ROC-AUC / PR-AUC rather than accuracy.>
@@ -58,11 +53,11 @@ the baseline note will weigh. Examples:>
   `TimeSeriesSplit`.>
 - <high-cardinality categoricals (`<cols>`) → skrub's default
   encoders handle these; flag if any need text encoding.>
-- <heavy target skew → consider a target transform; flag in the
-  baseline note's Risks.>
+- <heavy target skew → consider a target transform; note it as a
+  modelling risk.>
 
 ## Open questions
 
-<domain ambiguities for the user to confirm before / during the
-baseline: column meanings, sentinel values, whether a column is a
-leak, the true target definition, etc.>
+<domain ambiguities for the user to confirm before modelling: column
+meanings, sentinel values, whether a column is a leak, the true target
+definition, etc.>

--- a/skills/explore-ml-data/templates/eda.py
+++ b/skills/explore-ml-data/templates/eda.py
@@ -1,41 +1,13 @@
 # %% [markdown]
 # # EDA: <project / dataset name>
 #
-# Exploratory data analysis, run **before** any model is designed.
-# The agent executes this file via the shared in-process runner (see
-# `explore-ml-data` § "Execution contract") and reads the resulting
-# markdown digest from stdout, then authors `data/eda.md` and the
-# `journal/JOURNAL.md` § "Data understanding (EDA)" section from it.
+# Exploratory data analysis of <dataset>, run before designing a model.
 #
-# **Two locations, kept separate:**
-#
-# - **Raw data source** — user-owned, READ-ONLY. May live in `data/`,
-#   another in-repo folder (`raw/`, `inputs/`), an absolute path, or
-#   outside the repo. Set it at `RAW` below; it can be anything.
-# - **EDA deliverables** — always written under `EDA_DIR`
-#   (`<project>/data/`): the `eda_<table>.html` reports here, and
-#   `eda.md` authored by the agent. These are committed.
-#
-# **Hard rule (explore-ml-data § "Read-only-against-raw-data
-# contract"):** this file READS the raw data and writes ONLY the
-# `data/eda.*` deliverables. It MUST NOT clean, impute, drop, or
-# re-save the raw files — cleaning belongs in the pipeline
-# (`build-ml-pipeline`), applied at fit time.
-#
-# **Library-agnostic:** the structured facts come from `skrub`
-# (`TableReport`, `column_associations`), which work the same on
-# pandas and polars. The ONLY place a dataframe library appears is the
-# `RAW = <LOAD_RAW_DATA>` line you adapt. Do not reach for
-# pandas/polars-specific summary methods — read them off the skrub
-# report instead.
-#
-# **Bare-expression contract:** every code cell ends on a *text-
-# friendly* bare expression (a `dict`, a `list`, a `DataFrame`) so the
-# runner captures real values in the digest. NEVER end a cell on a
-# bare `skrub.TableReport(...)` — outside a notebook its repr is
-# `<TableReport: use .open() to display>`. Use `report.write_html(...)`
-# (a statement) for the rich HTML, and read facts from
-# `report.json()`.
+# - **Raw data** is read-only — point `RAW` at it below (it may live in
+#   `data/`, another folder, or an absolute path). This file never
+#   cleans or modifies the raw data.
+# - **Outputs** go under `EDA_DIR` (`<project>/data/`): an
+#   `eda_<table>.html` report per table, summarized in `eda.md`.
 
 # %%
 import json
@@ -44,38 +16,27 @@ import skrub
 
 from <pkg> import PROJECT_ROOT
 
-# Deliverables always land here (created if missing). This is NOT
-# necessarily where the raw data lives.
+# EDA outputs always land here (created if missing); the raw data may
+# live elsewhere.
 EDA_DIR = PROJECT_ROOT / "data"
 EDA_DIR.mkdir(parents=True, exist_ok=True)
 
 # %% [markdown]
 # ## Load the raw data
 #
-# Replace `<LOAD_RAW_DATA>` with the real load of the raw file(s),
-# wherever they live. Examples:
-#
-#   RAW = pd.read_parquet(PROJECT_ROOT / "data" / "train.parquet")
-#   RAW = pd.read_csv(Path("/abs/path/or/other_folder/train.csv"))
-#   RAW = pl.read_parquet("s3://bucket/train.parquet")
-#
-# Use the workspace's tabular library (G-TABULAR: pandas or polars);
-# skrub accepts both. End the cell on `RAW.shape`. For multiple tables,
-# load each into its own variable and repeat the overview cell per
-# table.
+# Load the raw table(s) into `RAW`. With several tables, load each into
+# its own variable and repeat the overview cell per table.
 
 # %%
 RAW = <LOAD_RAW_DATA>
 RAW.shape
 
 # %% [markdown]
-# ## Table overview (skrub TableReport)
+# ## Table overview
 #
-# `TableReport` is the user-facing artifact: write it to
-# `data/eda_<table>.html` (rich, interactive — types, distributions,
-# associations). For the agent digest, read structured per-column
-# stats off `report.json()` instead of ending on the report object.
-# `verbose=0` keeps progress prints out of the digest.
+# Per-table report (column types, distributions, associations) saved to
+# `data/eda_<table>.html`, plus a compact per-column summary: dtype,
+# fraction missing, and number of unique values.
 
 # %%
 report = skrub.TableReport(RAW, title="<table>", verbose=0)
@@ -97,13 +58,9 @@ overview = [
 # %% [markdown]
 # ## Target
 #
-# Drives the metric default and whether the splitter should stratify
-# (classification) or whether the target is skewed (regression). Read
-# the target column's entry from the same `report.json()` — it carries
-# the value counts (low-cardinality) or the distribution summary
-# (numeric), so this works for both task types without library-
-# specific code. Delete this cell if the task is unsupervised / the
-# target is unknown.
+# The target's distribution — class balance for classification, or
+# spread / skew for regression. This shapes the metric and whether
+# cross-validation should stratify.
 
 # %%
 TARGET = "<TARGET_COLUMN>"
@@ -112,12 +69,9 @@ next((col for col in summary.get("columns", []) if col.get("name") == TARGET), N
 # %% [markdown]
 # ## Structure signals
 #
-# Candidate datetime columns (→ consider `TimeSeriesSplit`) and
-# high-cardinality id / group-like columns (→ consider `GroupKFold`).
-# Both come from the skrub summary: skrub infers datetime types even
-# from string columns, and the unique ratio flags id/group columns.
-# This cell only surfaces the evidence; the splitter pick is
-# `G-CV-SPLITTER`.
+# Datetime columns (which point to time-based validation) and
+# high-cardinality id / group-like columns (which point to grouped
+# validation, to avoid leaking an entity across folds).
 
 # %%
 datetime_cols = [
@@ -141,18 +95,15 @@ unique_ratio = sorted(
 # %% [markdown]
 # ## Associations
 #
-# `skrub.column_associations` ranks pairwise column associations
-# (library-agnostic; returns a small table). Strong feature↔target
-# links are candidate predictors; an implausibly perfect link is a
+# Strongest pairwise column associations. Strong feature↔target links
+# are candidate predictors; an implausibly perfect one is a possible
 # leakage flag to call out explicitly.
 
 # %%
 skrub.column_associations(RAW).head(20)
 
 # %% [markdown]
-# ## End of EDA
+# ## Summary
 #
-# Re-running this file overwrites `data/eda_<table>.html` and the
-# `scratch/eda/` digest. Now author `data/eda.md` (findings +
-# **modelling implications**) and the `journal/JOURNAL.md` § "Data
-# understanding (EDA)" summary from the digest above.
+# The findings and their modelling implications are written up in
+# `data/eda.md`.

--- a/skills/iterate-ml-experiment/SKILL.md
+++ b/skills/iterate-ml-experiment/SKILL.md
@@ -102,10 +102,10 @@ then jump.
 | `journal/` not scaffolded (no `src/`, no `experiments/`) | **Bootstrap → handoff first** | → `organize-ml-workspace`, then § 0 |
 | "what's next?" / "let's iterate" / "propose next" — with ≥1 done row | **Iterate (propose)** | §§ 1–3 + Dispatch table |
 | "the run finished" / "log the result" / "we got X = …" | **Iterate (record)** | § 4 |
-| "where are we?" / "status?" / "what have we tried?" | **Project overview** | `references/maintenance_modes.md` § Overview |
-| "compare X and Y" / "X vs Y" | **Compare (read-only)** | `references/maintenance_modes.md` § Compare |
-| "let's pivot the goal" / "actually we care about <metric>" | **Goal pivot** | `references/maintenance_modes.md` § Goal pivots |
-| "abandon X" / "drop X" | **Abandoned** | `references/maintenance_modes.md` § Abandoned |
+| "where are we?" / "status?" / "what have we tried?" | **Project overview** | `references/maintenance_modes.md` § "Project overview" |
+| "compare X and Y" / "X vs Y" | **Compare (read-only)** | `references/maintenance_modes.md` § "Compare past experiments" |
+| "let's pivot the goal" / "actually we care about <metric>" | **Goal pivot** | `references/maintenance_modes.md` § "Goal pivots" |
+| "abandon X" / "drop X" | **Abandoned** | `references/maintenance_modes.md` § "Abandoned experiments" |
 | Re-do a prior experiment under different conditions | **Re-run** | `references/maintenance_modes.md` § Re-runs |
 
 If two modes seem to match ("compare X and Y, then propose"), pick
@@ -157,7 +157,7 @@ the **read** mode first, stop. Re-entering § 1 is a separate turn.
 | User said "quick baseline" → skip G-DESIGN | G-DESIGN is non-negotiable; "quick" never waives it. The design note is the postmortem's frozen Method |
 | Scaffold + implement in one turn before G-DESIGN | Inverts the contract. Code that lands before approval has no Motivation/Risks the user signed off on |
 | Skipped `evaluate-ml-pipeline` because `KFold(5)` "feels right" | Even empty `split_kwargs` is a justified pick the skill exists to surface. Bypass = user never got the choice |
-| Bootstrap mode → skip ALL questions, not just the sourcing menu | Bootstrap forbids the sourcing menu only. G-PKG-NAME / G-ENV-MGR / G-TABULAR / G-SKORE-MODE / G-CV-SPLITTER / G-DESIGN / G-RUN still fire |
+| Bootstrap mode → skip ALL questions, not just the sourcing menu | Bootstrap forbids the sourcing menu only. G-PKG-NAME / G-ENV-MGR / G-TABULAR / G-SKORE-MODE / G-EDA / G-DESIGN / G-CV-SPLITTER / G-RUN still fire |
 | Ambiguous "hmm interesting" / "I guess" read as approval | Approval is explicit. Ambiguity → re-ask, never silent yes |
 | Auto-detect run finished via `reports/` mtime | § 4 is user-triggered (v1). The skill never auto-records |
 | § 4 finishes recording → declare done, skip audit dispatch | § 4 audit dispatch is part of record-outcome, not optional. The audit digest carries the headline metrics for the JOURNAL row |
@@ -184,10 +184,12 @@ Pre-flight (iterate-ml-experiment):
       Evidence: AskUserQuestion id=<id>, answer=<skore|user|my-pick|B<N>>
                 | user free-text quote turn N
                 | "n/a — bootstrap / read-only mode"
-- [ ] (Bootstrap only) Config gates fired (G-PKG-NAME, G-ENV-MGR,
-      G-TABULAR, G-SKORE-MODE, G-CV-SPLITTER)
+- [ ] (Bootstrap only) Upfront config gates fired (G-PKG-NAME,
+      G-ENV-MGR, G-TABULAR, G-SKORE-MODE)
       Evidence: per-gate ask id OR JOURNAL.md Status reference
                 | "n/a — iterate mode"
+      Note: G-CV-SPLITTER is NOT an upfront gate — it fires later, in
+      the § 3 chain at the evaluation step (after G-DESIGN).
 - [ ] (Bootstrap only) G-EDA fired BEFORE the baseline draft
       Evidence: explore-ml-data dispatched; answer=<run|skip>;
                 JOURNAL.md `## Data understanding (EDA)` section present
@@ -201,6 +203,10 @@ Pre-flight (iterate-ml-experiment):
 - [ ] (§ 3 only) Three-skill chain ran in order:
       build → evaluate → test
       Evidence: each owning skill produced its file this turn
+                | "n/a outside § 3"
+- [ ] (§ 3 only) G-CV-SPLITTER resolved during the evaluate step
+      Evidence: evaluate-ml-pipeline fired the splitter AskUserQuestion
+                (or mapped split_kwargs) before `evaluate.py` write
                 | "n/a outside § 3"
 - [ ] (§ 3 only) G-RUN resolved: run now | leave for later
       Evidence: AskUserQuestion id=<id> | "n/a outside § 3"
@@ -232,16 +238,21 @@ placeholder, or has 0 History rows.
    run it executes `data/eda.py`, writes `data/eda.md` + HTML, and
    fills the `## Data understanding (EDA)` JOURNAL section. The
    findings (target balance / skew, datetime / group columns,
-   missingness, cardinality) feed the next step's learner / splitter /
-   metric defaults. The run path needs the agent feature (`ipython`)
-   and may trigger `G-AGENT-FEATURE` here, before the baseline; if the
-   user declines it, EDA falls back to **skip**. On skip, the JOURNAL
+   missingness, cardinality) feed the next step's learner and metric
+   defaults and inform the CV strategy chosen later at the evaluation
+   step. The run path needs the agent feature (`ipython`) and may
+   trigger `G-AGENT-FEATURE` here, before the baseline; if the user
+   declines it, EDA falls back to **skip**. On skip, the JOURNAL
    section records `Status: skipped`.
 5. **Auto-draft `journal/01_baseline.md`** via the consultation
    chain, **informed by the EDA findings**: learner default
-   (`build-ml-pipeline`), splitter default (`evaluate-ml-pipeline`),
-   metric default (`python-api` on skore.evaluate). Conflicts with the
-   EDA findings or the goal → flag in **Risks**, don't override.
+   (`build-ml-pipeline`) and metric default (`python-api` on
+   skore.evaluate). **Do NOT fix a splitter here** — the
+   cross-validation strategy is data-driven and decided at the
+   evaluation step (`G-CV-SPLITTER`, owned by `evaluate-ml-pipeline`)
+   once the pipeline's X-marker exists; the note simply records that it
+   is decided then. Conflicts with the EDA findings or the goal → flag
+   in **Risks**, don't override.
 6. **User's role in bootstrap is approve or amend** — not invent.
 7. **Exit bootstrap** once the baseline is approved and recorded.
    Audit file lands at first § 4 record-outcome.
@@ -260,8 +271,8 @@ placeholder, or has 0 History rows.
 | `G-SKORE-MODE` | Skore Project mode (local / hub / mlflow) + hub workspace name or MLflow tracking URI | `organize-ml-workspace` | before `pyproject.toml` write |
 | `G-EDA` | Explore the data (run / skip) before the baseline is designed | `explore-ml-data` | before the `journal/01_baseline.md` draft |
 | `G-AGENT-FEATURE` | Install ipython + pyright (install / skip) | `python-env-manager` | **conditional** — when G-EDA = run and the agent feature isn't present (else first audit at § 4) |
-| `G-CV-SPLITTER` | CV family for `skore.evaluate` | `evaluate-ml-pipeline` | before `evaluate.py` write — mandatory even with empty `split_kwargs` |
-| `G-DESIGN` | User approval of `journal/01_baseline.md` | this skill | before `experiments/01_baseline.py` write |
+| `G-DESIGN` | User approval of `journal/01_baseline.md` | this skill | before any `src/<pkg>/` or `experiments/` code — i.e. before the § 3 chain |
+| `G-CV-SPLITTER` | CV family for `skore.evaluate` | `evaluate-ml-pipeline` | **inside the § 3 chain, AFTER G-DESIGN** — at the evaluate step, before `evaluate.py` write; mandatory even with empty `split_kwargs` |
 | `G-RUN` | "run now" vs "leave for later" | this skill | before executing the experiment script |
 
 Free-text "quick baseline" / "you pick" do NOT resolve any of

--- a/skills/iterate-ml-experiment/references/bootstrap.md
+++ b/skills/iterate-ml-experiment/references/bootstrap.md
@@ -60,9 +60,10 @@ the **G-EDA** gate — binary **run** / **skip**:
 
 Why before the baseline: the dataset facts EDA surfaces (target
 balance / skew, datetime / group structure, missingness,
-cardinality, leakage flags) are exactly what justifies the learner /
-splitter / metric defaults in Step 4. Designing first and exploring
-later defeats the purpose and is the named anti-pattern.
+cardinality, leakage flags) are exactly what justifies the learner
+and metric defaults in Step 4 and informs the CV strategy chosen
+later at the evaluation step. Designing first and exploring later
+defeats the purpose and is the named anti-pattern.
 
 Free-text "go fast" / "quick baseline" does NOT resolve G-EDA — fire
 the `AskUserQuestion` (run / skip).
@@ -77,19 +78,24 @@ when EDA ran):
   "baseline" means for the data shape (tabular regression /
   classification → `skrub.tabular_pipeline`; other shapes have
   their own defaults).
-- **Splitter default**: consult `evaluate-ml-pipeline` for the
-  cross-validator default (typically `KFold` for IID tabular, but
-  the skill picks based on data structure).
+- **Cross-validation strategy**: NOT fixed in the design note. The
+  splitter is data-driven and chosen at the evaluation step
+  (`G-CV-SPLITTER`, owned by `evaluate-ml-pipeline`) once the
+  pipeline's X-marker / `split_kwargs` exist — so the design note only
+  records that the CV strategy is decided then, it does not commit a
+  specific splitter. (EDA's structure signals still *inform* that
+  later choice; they don't pre-empt it.)
 - **Metric default**: consult `python-api` for what
   `skore.evaluate` reports by default for the task type.
 
 ### Mismatch handling
 
-If any default conflicts with the project goal — e.g., the README
-requires Squared Error but skore's default is RMSE; the dataset
-has 1M rows and 5-fold KFold may be slow / OOM — **flag it in the
+If a default conflicts with the project goal — e.g., the README
+requires Squared Error but skore's default is RMSE — **flag it in the
 Risks section** of `01_baseline.md`. Don't silently override the
-default; surface the tension to the user.
+default; surface the tension to the user. Splitter concerns (group /
+temporal structure, fold cost) are surfaced and resolved at the
+evaluation step, not pre-committed here.
 
 ## Step 5 — The user's role: approve or amend, not invent
 
@@ -126,20 +132,24 @@ gate the workflow normally fires still fires.
 | `G-PKG-NAME` | `src/<pkg>/` import name | `organize-ml-workspace` | **Before** any `pyproject.toml` / `pixi.toml` creation |
 | `G-ENV-MGR` | Python env manager (`pixi`, `uv`, `poetry`, `hatch`, `conda`, `pip+venv`). The 3-feature layout (`default` / `dev` / `agent`) is enforced automatically — no scope sub-pick. | `python-env-manager` | **Before** any `pixi init` / `pixi add` / equivalent |
 | `G-TABULAR` | Tabular library (`pandas` / `polars`) + other Tier 2 contested-library picks | `data-science-python-stack` | **Before** any `Write` of `data.py` / experiment script importing the contested library |
-| `G-EDA` | Explore the data (run / skip) | `explore-ml-data` | **Before** the `journal/01_baseline.md` draft — so EDA findings can inform the learner / splitter / metric defaults |
+| `G-SKORE-MODE` | Skore Project mode (`local` / `hub` / `mlflow`) + hub workspace name or MLflow tracking URI | `organize-ml-workspace` | **Before** any `pyproject.toml` write / the skore install variant |
+| `G-EDA` | Explore the data (run / skip) | `explore-ml-data` | **Before** the `journal/01_baseline.md` draft — so EDA findings can inform the learner / metric defaults and the later CV-strategy choice |
 | `G-AGENT-FEATURE` | Install `ipython` + `pyright` (install / skip) | `python-env-manager` | **Conditional** — fires when G-EDA = run and the agent feature isn't present (the EDA cell runner needs `ipython`). Otherwise deferred to the first audit at § 4. Decline → EDA falls back to skip |
-| `G-CV-SPLITTER` | Cross-validator family for `skore.evaluate` (`KFold`, `StratifiedKFold`, `GroupKFold`, `TimeSeriesSplit`, ...) | `evaluate-ml-pipeline` | **Before** any `Write` of `src/<pkg>/evaluate.py`; mandatory even when `split_kwargs` is empty (the empty case is itself a justified pick) |
 | `G-DESIGN` | Explicit user approval of `journal/01_baseline.md` | `iterate-ml-experiment` § 3 | **Before** any `Write` of `experiments/01_baseline.py` / `src/<pkg>/*.py` content authored from the design note |
+| `G-CV-SPLITTER` | Cross-validator family for `skore.evaluate` (`KFold`, `GroupKFold`, `TimeSeriesSplit`, ...) | `evaluate-ml-pipeline` | **Inside the § 3 chain, AFTER G-DESIGN** — at the evaluate step, before any `Write` of `src/<pkg>/evaluate.py`; mandatory even when `split_kwargs` is empty (the empty case is itself a justified pick). NOT an upfront config gate |
 | `G-RUN` | "Run now" vs "leave for later" once smoke tests pass | `iterate-ml-experiment` § 3 | **Before** the shell call that executes `experiments/01_baseline.py` |
 
 Each gate's owning skill is responsible for the actual
 `AskUserQuestion` mechanics; this table is the **bootstrap
 contract** that says they all still fire even though the sourcing
-menu doesn't. Every persistent gate's answer is recorded in
-`JOURNAL.md` Status `Workspace decisions` (the first four) so a
-later session can read the decision instead of re-asking.
-`G-DESIGN` and `G-RUN` are per-experiment, not persistent — they
-fire fresh on every experiment.
+menu doesn't. The persistent gates (`G-PKG-NAME`, `G-ENV-MGR`,
+`G-TABULAR`, `G-SKORE-MODE`, and the post-build `G-CV-SPLITTER`) are
+recorded in `JOURNAL.md` Status `Workspace decisions` so a later
+session reads the decision instead of re-asking; `G-EDA` is recorded
+in the `Data understanding (EDA)` section. `G-DESIGN`, `G-RUN`, and
+`G-AGENT-FEATURE` are not `Workspace decisions` rows — `G-DESIGN` /
+`G-RUN` are per-experiment, and the agent-feature status has its own
+row owned by `python-env-manager`.
 
 ### Free-text doesn't resolve config gates
 

--- a/skills/iterate-ml-experiment/references/record_outcome.md
+++ b/skills/iterate-ml-experiment/references/record_outcome.md
@@ -53,7 +53,7 @@ digest doesn't carry), the probe goes to
 `scratch/<YYYY-MM-DD>_<HHMMSS>_<short>.py` and runs via
 `pixi run python scratch/<ts>_<short>.py`.
 
-See `python-api` § "Scratch traceability" for the full
+See `python-api` § "`scratch/` conventions" for the full
 convention. **Inline `pixi run python -c "..."` is forbidden
 regardless of length** (see `python-api` § Stop conditions).
 

--- a/skills/iterate-ml-experiment/templates/JOURNAL.md
+++ b/skills/iterate-ml-experiment/templates/JOURNAL.md
@@ -1,16 +1,11 @@
 # JOURNAL
 
 <!--
-This file is the durable index of every experiment in this workspace.
-Four sections, in order: Status, Data understanding (EDA), History,
-Backlog. Don't add OTHER top-level sections; they break the contract
-that lets future sessions read this file in two seconds.
-
-Owner: `iterate-ml-experiment` skill (Status / History / Backlog).
-The `## Data understanding (EDA)` section is owned by `explore-ml-data`
-(written at the G-EDA bootstrap step). Pair each
-`journal/NN_short_name.md` with `experiments/NN_short_name.py`
-(identical stems).
+Durable index of every experiment in this workspace. Four sections,
+in order: Status, Data understanding (EDA), History, Backlog — keep
+them so the file stays quick to scan. Each journal/NN_short_name.md
+design note pairs one-to-one with experiments/NN_short_name.py (same
+stem).
 -->
 
 ## Status
@@ -21,34 +16,10 @@ The `## Data understanding (EDA)` section is owned by `explore-ml-data`
 - **Last result:** <one-line headline metric, or "n/a" if not yet run>
 
 <!--
-Workspace decisions: persistent picks for the config gates that fire in
-bootstrap (see `iterate-ml-experiment` § 0 "Bootstrap skips sourcing
-menu — NOT the config gates"). Each row records a one-time pick the
-user made via `AskUserQuestion`; on every later session, skills read
-this block first and skip the matching question.
-
-Immutability rule: rows are immutable unless the user explicitly pivots
-("let's switch to polars", "move env to uv"). Do NOT silently update
-a row because a newer tool would obviously fit better; surface the
-proposal and wait for the user. The `recorded:` date is the date the
-row was last user-confirmed.
-
-Adding rows: when a new competing-library job comes into scope
-mid-project (e.g. DL is added), the matching skill fires its
-`AskUserQuestion`, then this block gets a new row.
-
-Owning skills:
-  - tabular library     → data-science-python-stack § Tier 2
-  - env manager         → python-env-manager
-  - agent feature       → python-env-manager § "Agent feature"
-  - optional features   → python-env-manager § "Where does the package belong?"
-  - package name        → organize-ml-workspace
-  - CV splitter family  → evaluate-ml-pipeline
-
-The 3-feature env layout (default / dev / agent) is enforced by
-python-env-manager; no row is collected for it. The `agent feature`
-row only records whether the user opted into the agent feature
-install (ipython + pyright + pyrightconfig.json) or skipped it.
+Workspace decisions: one-time project-setup choices. Record each when
+it is made and treat it as fixed unless you deliberately change one
+(e.g. switch pandas → polars), updating the recorded date. Reading
+this block on later sessions avoids re-deciding what's already settled.
 -->
 
 - **Workspace decisions** (immutable unless the user pivots):
@@ -65,16 +36,14 @@ install (ipython + pyright + pyrightconfig.json) or skipped it.
 ## Data understanding (EDA)
 
 <!--
-Owned by `explore-ml-data`. Written at the G-EDA bootstrap step
-(before the baseline design note). Short index entry only — the full
-narrative lives in `data/eda.md`. On the skip path, keep just the
-`Status: skipped` line.
+Short index entry — the full analysis lives in data/eda.md. If the
+data exploration was skipped, keep just the Status: skipped line.
 -->
 
 - **Status:** <done | skipped> — <YYYY-MM-DD>
 - **Summary:** <2–4 lines — dataset shape, target balance/skew, and the
-  one or two findings that most shape the modelling choices. "n/a" until
-  the G-EDA gate fires.>
+  one or two findings that most shape the modelling choices. "n/a"
+  until the data has been explored.>
 - **Report:** [data/eda.md](../data/eda.md)
 
 ## History
@@ -91,32 +60,18 @@ Status values: planned | approved | running | done | abandoned.
 ## Backlog
 
 <!--
-Indexed table of ideas not yet committed to a `journal/NN_*.md` file.
-Each row carries a stable `B<N>` index so the user can pick by
-number when picking the next experiment ("go with B2"). The skill
-surfaces this table to the user every time it presents the
-sourcing menu.
+Ideas not yet committed to a journal/NN_*.md design note. Each row
+has a stable B<N> index so it can be picked by number ("go with B2").
 
 Columns:
-  - `#`      — stable index (B1, B2, ...). Don't renumber on
-               removal; new rows take the next free B<N>.
-  - `Item`   — one-line description of the idea.
-  - `Source` — where the idea came from. Use one of:
-                 `skore:<stem>`    — written by `iterate-from-skore`
-                                     from the report of `<stem>`
-                 `my-pick:<stem>`  — agent-synthesized; <stem> is
-                                     the experiment whose context
-                                     (Implication, Risks, …) fed
-                                     the synthesis. Written by § 4
-                                     when implications seed future
-                                     leads, or by § 2's my-pick
-                                     branch when unpicked
-                                     candidates are saved
-                 `user`            — the user added the row
-                                     directly (in conversation)
+  - #      — stable index (B1, B2, ...); don't renumber on removal.
+  - Item   — one-line description of the idea.
+  - Source — where it came from, e.g. a finding from a prior
+             experiment's report (`skore:<stem>`), a synthesized idea
+             (`my-pick:<stem>`), or a user request (`user`).
 
-When an item graduates into a design note, remove the row from this
-table and add the new experiment to History above.
+When an item becomes a design note, remove its row here and add the
+experiment to History above.
 -->
 
 | # | Item | Source |

--- a/skills/iterate-ml-experiment/templates/experiment_design.md
+++ b/skills/iterate-ml-experiment/templates/experiment_design.md
@@ -1,26 +1,19 @@
 # <NN>_<short_name>
 
 <!--
-Design note for `experiments/<NN>_<short_name>.py`. Same stem,
-one-to-one with the script. Owner: `iterate-ml-experiment`.
+Design note for experiments/<NN>_<short_name>.py (same stem, one to
+one with the script). Write and agree on it before creating the
+script.
 
 Lifecycle:
-  planned   → draft, not yet shown to the user / not approved
-  approved  → user said "go"; safe to create the matching .py
-  done      → result recorded; status block + JOURNAL.md row updated
-  abandoned → discarded; record one-line reason on State
+  planned   → draft, not yet approved
+  approved  → agreed; safe to create the matching .py
+  done      → result recorded; Status block + JOURNAL.md row updated
+  abandoned → discarded; record a one-line reason on State
 
-This skill is user-triggered (no polling, no auto-detection),
-so there is no observable "running" state — the experiment
-sits in `approved` from the moment the script is created until
-the user reports the outcome via § 4 ("the run finished, record
-it"), at which point it flips to `done` (or `abandoned`).
-
-Freeze rule: the four content sections (Question, Motivation,
-Method, Risks) are frozen at `approved`. Only the Status block
-is updated after that. **No "Success criteria" section** — the
-skill's job is to propose and run; the user judges whether the
-result is good enough.
+The four content sections (Question, Motivation, Method, Risks) are
+fixed once approved; only the Status block changes afterwards. There
+is no "Success criteria" section — judge the result once it is in.
 -->
 
 ## Question / hypothesis
@@ -30,45 +23,33 @@ result is good enough.
 ## Motivation
 
 <!--
-Why now. Cite the source concretely:
-  - user (free-text)    → quote the request the user typed
-  - user (article-link) → article title + year + URL + the exact
-                          claim to build on
-  - user (resource)     → GitHub issue link, or spec file:line,
-                          or reference-repo path
-  - my-pick             → which JOURNAL.md / prior-design-note fields fed
-                          the synthesis (Status, last Implication,
-                          last Risks, current Backlog state)
-  - skore               → audit-digest section + check code (e.g.
-                          `audit:<prev_stem>:checks.<SKD-code>`) +
-                          the check's documentation_url
-  - backlog (B<N>)      → the index promoted + the row's original
-                          Source carried forward
+Why now. Cite the source concretely — the request or article claim to
+build on, the finding from a prior experiment's report that prompted
+this, or the backlog item being promoted.
 -->
 
 - **Sourcing strategy:** <user | my-pick | skore:<stem> | backlog:B<N>>
 - **Source(s):**
   <!--
-  Single line is the right shape for most strategies. For an
-  article-link, paste the exact claim verbatim — the design
-  note becomes the postmortem and the original claim is what
-  makes the result interpretable later.
+  One line is enough for most cases. For an article, paste the exact
+  claim verbatim — it is what makes the result interpretable later.
   -->
   - <e.g. issue #42 / "Paper Title" (year) URL — "exact claim" /
-    `audit:01_baseline:checks.SKD003` + its documentation_url /
-    B2 (originally skore:01_baseline)>
+    a check from the 01_baseline report + its documentation_url /
+    B2 (originally from the 01_baseline report)>
 - **Why this matters:** <one or two sentences>
 
 ## Method
 
 <!--
-What changes versus the previous experiment, in prose. Which file
-in `src/<pkg>/` is touched? State intent, not code. Mechanics live
-in `build-ml-pipeline` / `evaluate-ml-pipeline`.
+What changes versus the previous experiment, in prose. Which file in
+src/<pkg>/ is touched? State intent, not code.
 -->
 
 - **Files touched:** <e.g., `src/<pkg>/features.py`, `src/<pkg>/evaluate.py`>
 - **Change versus baseline (or previous experiment):** <prose>
+- **Cross-validation:** decided at the evaluation step, data-driven
+  from the data's structure (groups / time ordering) — not fixed here.
 - **Out of scope for this experiment:** <what we are deliberately not changing>
 
 ## Risks / things that could invalidate the result
@@ -89,13 +70,12 @@ run (to interpret the headline result honestly).
 - **State:** planned
   <!--
   Lifecycle: planned → approved → running → done | abandoned.
-  - `done`: Headline result + Implication required (filled by § 4).
-  - `abandoned`: requires a one-line reason on this line itself
+  - `done`: fill Headline result + Implication.
+  - `abandoned`: add a one-line reason on this line itself
     (e.g., `abandoned — paper's required dep was non-trivial; deferred to v2`).
     Headline result becomes `n/a — abandoned: <reason>`.
     The row stays in JOURNAL.md History; only the State field flips.
-  - User-decided only: the skill never auto-abandons.
   -->
 - **Approved by user on:** <date or n/a>
 - **Headline result:** <fill in after run, or `n/a — abandoned: <reason>`>
-- **Implication for next iteration:** <fill in after run — feeds the next strategy dispatch. For abandonment: one line on what the abandonment teaches (e.g., "rules out monotonic-NN direction without paid GPU env")>
+- **Implication for next iteration:** <fill in after run — what it suggests to try next. For abandonment: one line on what the abandonment teaches (e.g., "rules out monotonic-NN direction without paid GPU env")>

--- a/skills/organize-ml-workspace/SKILL.md
+++ b/skills/organize-ml-workspace/SKILL.md
@@ -335,7 +335,7 @@ revisiting the matching smoke test
 | 8 | Create empty `scratch/` (no README — owned by `python-api`) | this skill |
 | 9 | Create empty `reports/` | this skill |
 | 10 | Touch `.gitignore` — drop template if none; else suggest patch (always ask about `reports/`). **Never ignore the whole `data/`** (EDA deliverables live there); to keep raw inputs out of git, ignore specific input paths only and ask | this skill |
-| 11 | **Hand off to `python-code-style`** § Initial setup for `ruff.toml` + first pass — invoking the skill teaches NumPyDoc | this skill → python-code-style |
+| 11 | **Hand off to `python-code-style`** § Initial setup for `ruff.toml` + first pass — invoking the skill teaches NumPyDoc and (once files carry real content) contextualizes their comments to the problem | this skill → python-code-style |
 | 12 | Hand back to the relevant sibling (`iterate-ml-experiment` for design note, etc.) | this skill → next caller |
 
 → next: `iterate-ml-experiment` § 0 (bootstrap) for the first

--- a/skills/organize-ml-workspace/references/g_skore_mode.md
+++ b/skills/organize-ml-workspace/references/g_skore_mode.md
@@ -74,7 +74,7 @@ Source: https://docs.skore.probabl.ai/stable/reference/api/skore.Project.html
 | `mode=` argument | `mode="local"` | `mode="hub"` | `mode="mlflow"` |
 | `workspace=` argument | **required**: `workspace=str(PROJECT_ROOT / "reports")` | **MUST be absent** — passing it raises `TypeError` | **MUST be absent** — `tracking_uri=` is used instead |
 | `tracking_uri=` argument | not used | not used | **required**: the MLflow tracking server URI |
-| Install variant | `pixi add skore` | `pixi add "skore[hub]"` | `pixi add "skore[mlflow]"` |
+| Install variant | `pixi add skore` | `pixi add "skore[hub]"` | `pixi add "skore[mlflow]" "mlflow>=3"` (pin required) |
 | Pre-condition | none | Skore Hub account + access to `<hub-workspace>` | reachable MLflow tracking server at `<uri>` |
 
 ## The gate — AskUserQuestion shape
@@ -151,7 +151,7 @@ artifacts:
 | Downstream artifact | local-mode shape | hub-mode shape | mlflow-mode shape |
 |---|---|---|---|
 | `<SKORE_PROJECT_INIT>` in `experiments/NN_*.py` and `audit/NN_*.py` | `skore.Project(name="<project-name>", mode="local", workspace=str(PROJECT_ROOT / "reports"))` | `from skore import login; login(mode="hub"); skore.Project("<hub-workspace>/<project-name>", mode="hub")` | `skore.Project(name="<experiment-name>", mode="mlflow", tracking_uri="<mlflow-tracking-uri>")` |
-| Tier 1 skore install variant (per `python-env-manager` § Tier 1 install) | `pixi add skore` (or equivalent) | `pixi add "skore[hub]"` (or equivalent) | `pixi add "skore[mlflow]"` (or equivalent) |
+| Tier 1 skore install variant (per `python-env-manager` § Tier 1 install) | `pixi add skore` (or equivalent) | `pixi add "skore[hub]"` (or equivalent) | `pixi add "skore[mlflow]" "mlflow>=3"` (or equivalent — the `mlflow>=3` pin is required) |
 | `Workspace decisions` rows in `JOURNAL.md` | `skore mode: local` | `skore mode: hub` + `skore hub workspace: <name>` | `skore mode: mlflow` + `skore mlflow tracking uri: <uri>` |
 
 The `name=` argument shape **changes between modes** — local uses a
@@ -196,7 +196,7 @@ Procedure:
 3. Rewrite **every** `<SKORE_PROJECT_INIT>` block in `experiments/`
    AND `audit/`.
 4. Update the install variant via `python-env-manager` (plain
-   `skore` ↔ `skore[hub]` ↔ `skore[mlflow]`).
+   `skore` ↔ `skore[hub]` ↔ `skore[mlflow]` + `mlflow>=3`).
 5. Document the switch in `JOURNAL.md` History as a horizontal
    divider (same shape as goal pivots — see `iterate-ml-experiment`
    § Maintenance modes).

--- a/skills/organize-ml-workspace/references/scaffold_steps.md
+++ b/skills/organize-ml-workspace/references/scaffold_steps.md
@@ -109,8 +109,8 @@ script runs.
 ## Step 8 — Empty `scratch/`
 
 Just `mkdir scratch`. **Do NOT drop a README inside** — the
-scratch convention is owned by `python-api` § "Scratch
-traceability" and lives in that skill, not in a file on disk.
+scratch convention is owned by `python-api` § "`scratch/`
+conventions" and lives in that skill, not in a file on disk.
 The folder is the agent's ad-hoc workspace; its contents are
 gitignored entirely via step 10.
 

--- a/skills/organize-ml-workspace/templates/.gitignore
+++ b/skills/organize-ml-workspace/templates/.gitignore
@@ -14,11 +14,11 @@ dist/
 .ruff_cache/
 .mypy_cache/
 
-# data artifacts — user owns the data/ layout.
-# NEVER ignore the whole data/ folder: the EDA deliverables
-# (data/eda.py, data/eda.md, data/eda_*.html, owned by explore-ml-data)
-# live there and must stay committable. To keep large/local-only raw
-# INPUTS out of git, ignore specific input paths only, e.g.:
+# data artifacts — you own the data/ layout.
+# Do NOT ignore the whole data/ folder: the EDA outputs
+# (data/eda.py, data/eda.md, data/eda_*.html) live there and should
+# stay committed. To keep large/local-only raw INPUTS out of git,
+# ignore specific input paths only, e.g.:
 # data/raw/
 # data/*.parquet
 # data/*.csv
@@ -26,8 +26,7 @@ dist/
 # skore Project store — large/binary; commit selectively if at all
 reports/
 
-# agent scratch space — gitignored entirely; convention lives in the
-# `python-api` skill (§ "Scratch traceability"), not in an on-disk README
+# agent scratch space — gitignored entirely
 scratch/
 
 # mlflow filesystem fallback (sqlite backend is .db; keep both ignored to be safe)

--- a/skills/organize-ml-workspace/templates/experiment.py
+++ b/skills/organize-ml-workspace/templates/experiment.py
@@ -30,30 +30,9 @@ DATA_DIR = PROJECT_ROOT / "data"
 # %% [markdown]
 # ## Project
 #
-# One project per workspace; each experiment writes its report under a
-# stable key (the file stem). The Project init block below is filled
-# at scaffold time per the workspace's `skore mode:` decision
-# (recorded in `journal/JOURNAL.md` Status `Workspace decisions`; see
-# `organize-ml-workspace` § "G-SKORE-MODE"). Three forms:
-#
-# - **local mode**: `skore.Project(name=..., mode="local",
-#   workspace=str(PROJECT_ROOT / "reports"))`. Reports persist to disk
-#   under `reports/`. No account or login required.
-# - **hub mode**: `skore.login(mode="hub")` first (interactive on
-#   first run; cached after), then `skore.Project("<hub-workspace>/
-#   <project-name>", mode="hub")`. Reports persist on Skore Hub.
-#   Requires `pip install "skore[hub]"` (see `python-env-manager` §
-#   "Tier 1 install: skore variant per mode") and a Skore Hub
-#   account with access to the named hub workspace.
-# - **mlflow mode**: `skore.Project(name="<experiment-name>",
-#   mode="mlflow", tracking_uri="<mlflow-tracking-uri>")`. Reports are
-#   pushed to an MLflow tracking server as runs under the named
-#   experiment. No `login()`. Requires `pip install "skore[mlflow]"`
-#   and a reachable tracking server (or local `file:`/`sqlite:`
-#   backend) at the recorded URI.
-#
-# `<SKORE_PROJECT_INIT>` is replaced by the right form at scaffold
-# time. Do NOT keep multiple forms in the same file — only one is valid.
+# Open the project that stores this experiment's report under a stable
+# key (the file stem). All reports for this workspace live together so
+# they can be compared across experiments.
 
 # %%
 # <SKORE_PROJECT_INIT>
@@ -78,9 +57,9 @@ learner = build_learner(data_dir_preview=DATA_DIR)
 # ## Evaluate
 #
 # Cross-validator and any metric overrides are imported from
-# `<pkg>.evaluate`. The experiment script does not redefine them.
-# `SkrubLearner.fit` takes a single environment dict (it does *not*
-# implement `fit(X, y)`), so we pass the bindings via `data=`. Use
+# `<pkg>.evaluate`. `SkrubLearner.fit` takes a single environment dict
+# (it does *not* implement `fit(X, y)`), so we pass the bindings via
+# `data=`. Use
 # the source-bound form (`data={"data_dir": str(DATA_DIR)}`) when the
 # pipeline binds a source identifier; use `data={"X": X, "y": y}` for
 # materialized bindings.

--- a/skills/organize-ml-workspace/templates/pyproject.toml
+++ b/skills/organize-ml-workspace/templates/pyproject.toml
@@ -9,11 +9,9 @@
 # Replace `<pkg>` with the actual package name (kebab-case for
 # `project.name`, snake_case for the `src/<pkg>/` directory).
 #
-# After this file is on disk, `python-env-manager` § "Editable
-# workspace package" wires the editable install for the project's
-# manager (pixi: `pixi add --pypi "<pkg> @ ."` then edit
-# `[pypi-dependencies]` to set `editable = true`; uv: `uv sync` is
-# enough; poetry/hatch: declarative; pip+venv: `pip install -e .`).
+# Install the package in editable mode with the project's environment
+# manager (e.g. `pip install -e .`, or the manager's equivalent) so
+# `from <pkg>.X import Y` resolves from any working directory.
 
 [build-system]
 requires = ["setuptools>=64"]

--- a/skills/organize-ml-workspace/templates/src___init__.py
+++ b/skills/organize-ml-workspace/templates/src___init__.py
@@ -6,10 +6,9 @@ a project-relative path (data files, fixtures, configs) imports this
 constant instead of hard-coding a CWD-relative string. This is what
 lets experiment scripts run from any CWD without breaking.
 
-This works because the package is installed in **editable** mode
-(see `python-env-manager` § "Editable workspace package"); `__file__`
-points back into the source tree at `<root>/src/<pkg>/__init__.py`,
-so `parents[2]` is the project root.
+This works because the package is installed in **editable** mode, so
+`__file__` points back into the source tree at
+`<root>/src/<pkg>/__init__.py` and `parents[2]` is the project root.
 
 If the workspace ever moves away from a `src/` layout, replace the
 `parents[2]` walk with an upward search for an anchor file (e.g.

--- a/skills/organize-ml-workspace/templates/src_data.py
+++ b/skills/organize-ml-workspace/templates/src_data.py
@@ -2,9 +2,8 @@
 
 Owns: how raw data is materialized into `(X, y)`, and how structural
 metadata (groups, time ordering, ...) is attached at the X marker via
-`split_kwargs`. Pipeline mechanics live in `build-ml-pipeline`; data
-paths are decided by the caller — this module does not invent a
-`data/` directory.
+`split_kwargs`. Data paths are decided by the caller — this module
+does not invent a `data/` directory.
 """
 
 from __future__ import annotations

--- a/skills/organize-ml-workspace/templates/src_evaluate.py
+++ b/skills/organize-ml-workspace/templates/src_evaluate.py
@@ -1,20 +1,17 @@
 """Inputs to `skore.evaluate`.
 
-This module is **strictly limited** to objects consumed by
-`skore.evaluate(...)` calls in the experiment scripts:
+Holds only the objects passed to `skore.evaluate(...)`:
 
-- `splitter` — the cross-validator (chosen per
-  `evaluate-ml-pipeline`); fed straight into
-  `skore.evaluate(..., splitter=splitter)`,
-- optional metric overrides, only when the user has explicitly
-  asked for them (skore picks task-appropriate defaults otherwise).
+- `splitter` — the cross-validator,
+- optional metric overrides (skore picks task-appropriate defaults
+  otherwise).
 
-It must NOT call `skore.evaluate`, open a `skore.Project`, or
-persist anything. Those steps belong in the experiment script.
+The evaluation itself — running `skore.evaluate`, opening a project,
+persisting the report — happens in the experiment scripts, not here.
 """
 
 from __future__ import annotations
 
-# Pick the cross-validator from the structural facts of the data.
-# See `evaluate-ml-pipeline` for the mapping rules.
+# Pick the cross-validator from the structural facts of the data
+# (grouping, time ordering, class balance).
 splitter = None  # e.g., KFold(n_splits=5, shuffle=True, random_state=0)

--- a/skills/organize-ml-workspace/templates/src_features.py
+++ b/skills/organize-ml-workspace/templates/src_features.py
@@ -3,8 +3,7 @@
 Owns: pure-Python feature functions (stateless, attached to the
 pipeline via `.skb.apply_func`) and sklearn-compatible transformers
 (stateful, attached via `.skb.apply`). Composition into the learner
-happens in `pipeline.py`. See `build-ml-pipeline` for declarative
-mechanics.
+happens in `pipeline.py`.
 """
 
 from __future__ import annotations

--- a/skills/organize-ml-workspace/templates/src_pipeline.py
+++ b/skills/organize-ml-workspace/templates/src_pipeline.py
@@ -4,7 +4,6 @@ Owns: the function that builds and returns the (unfit) learner —
 typically a `SkrubLearner` produced from a skrub DataOps graph that
 composes the steps in `data.py` and `features.py` with the chosen
 estimator. Fitting, evaluation, and persistence happen elsewhere.
-See `build-ml-pipeline` for the declarative mechanics.
 
 Note on the source-binding preview. When the graph roots a
 `skrub.var(name, value=...)` on a source identifier (path, URL,
@@ -15,7 +14,7 @@ is intentionally exposed as an **optional** keyword on
 pass an absolute path resolved from the package root, instead of a
 CWD-relative literal baked into this file. Without a preview, the
 graph still fits and evaluates — only `.skb.preview()` is
-unavailable. See `build-ml-pipeline` rule 2.
+unavailable.
 """
 
 from __future__ import annotations

--- a/skills/python-api/references/skrub_interop.md
+++ b/skills/python-api/references/skrub_interop.md
@@ -249,7 +249,7 @@ Note the clean separation:
 - **`splitter`** is the project's chosen cross-validator (the
   walk-forward splitter in `src/load_forecast/evaluate.py`).
 - **No agent-only `print` calls** — inspection is the agent's
-  scratch problem (see `python-api` § "Scratch traceability"),
+  scratch problem (see `python-api` § "`scratch/` conventions"),
   not the script's. The bare `report` line is jupytext display,
   not a debug print.
 

--- a/skills/python-api/references/stack_orientation.md
+++ b/skills/python-api/references/stack_orientation.md
@@ -72,7 +72,9 @@ finds the right submodule.
     https://skore.probabl.ai with access to the workspace.
   - **mlflow**: `skore.Project(name="<experiment>", mode="mlflow",
     tracking_uri="<uri>")`. `name=` is the MLflow experiment name.
-    Requires `pip install "skore[mlflow]"`.
+    Requires `pip install "skore[mlflow]" "mlflow>=3"` (the explicit
+    `mlflow>=3` pin is required — `skore[mlflow]` alone can resolve an
+    unsupported mlflow 2.x).
 
   Methods (same surface across modes): `put(key, report)`,
   `get(id)` (**by id, not by `key`** — get the id from

--- a/skills/python-code-style/SKILL.md
+++ b/skills/python-code-style/SKILL.md
@@ -2,16 +2,22 @@
 name: python-code-style
 description: >
   Owns Python code style for this stack: ruff for lint + format, numpydoc
-  for docstrings. Two responsibilities — (1) place the project's
+  for docstrings. Three responsibilities — (1) place the project's
   `ruff.toml` from the bundled template once the stack and workspace
-  are in place, and (2) run ruff against any Python files Claude has
-  just generated or edited. Stops at "the touched files pass `ruff
-  check`."
+  are in place, (2) run ruff against any Python files Claude has
+  just generated or edited, and (3) contextualize each touched file's
+  comments to the data-science problem — rewriting any leftover
+  template / workflow prose (skill names, gates, runner, digest,
+  guard-rails) into concise, problem-specific docs so the user's
+  committed files read like a colleague wrote them, not like a
+  generated scaffold. Stops at "the touched files pass `ruff check`
+  and document the problem, not the process."
 
   TRIGGER when (any of these):
   (1) a Python file was just created or edited via Write / Edit /
       MultiEdit — invoke this skill before declaring the task done so
-      ruff is run on the touched files;
+      ruff is run AND the file's comments are contextualized to the
+      problem;
   (2) a fresh ML workspace was just scaffolded by
       `organize-ml-workspace` and the project has no `ruff.toml` at
       its root yet — drop the bundled template;
@@ -77,6 +83,20 @@ touched, no hook involved.
   `@pytest.mark.filterwarnings`, and `filterwarnings = [...]` in
   `pytest.ini` / `pyproject.toml`. Warnings are signal in this
   stack.
+- **Documentation describes the problem, not the workflow.** A
+  committed file's module docstring, header, and comments must
+  describe the **data-science problem** and the file's role in it —
+  never the skills, the gates (`G-*`), the cell runner, the run
+  digest, the journal / backlog / design-note machinery, or "the
+  process we are following". That guidance is agent-facing and lives
+  in the skills, not in the user's files. When you touch a file that
+  now carries **real content**, rewrite any leftover generic template
+  or workflow prose into concise, problem-specific docs grounded in
+  the current context (the project goal, the experiment's hypothesis,
+  the dataset). If the file is still an empty skeleton (no content /
+  no context yet), leave its placeholder — the contextualization
+  happens when the content lands. Details: § "Contextualize the
+  comments".
 
 ## Pre-flight — emit this checklist as visible text before running ruff
 
@@ -98,6 +118,12 @@ Pre-flight (python-code-style):
       issues) | third pass on same warning (STOP, surface to user)
 - [ ] One-fix-per-file rule acknowledged: max two passes per warning,
       then surface remaining diagnostics + diff to the user.
+- [ ] Comments contextualized: each touched file with real content has
+      problem-specific docs and NO workflow/skill/gate/runner/digest
+      meta (§ "Contextualize the comments")
+      Evidence: per file, "rewrote header to <problem context>" |
+                "no leftover template/workflow prose" |
+                "n/a — empty skeleton, no context yet"
 ```
 
 ## Scope
@@ -105,7 +131,9 @@ Pre-flight (python-code-style):
 - **In scope:** running `ruff format` + `ruff check --fix` + `ruff
   check` on Python files Claude has just generated or edited;
   authoring numpydoc docstrings on public functions and classes;
-  dropping the `ruff.toml` template into a fresh project.
+  contextualizing each touched file's comments to the data-science
+  problem and stripping workflow/process meta (§ "Contextualize the
+  comments"); dropping the `ruff.toml` template into a fresh project.
 - **Out of scope:** type hints (mypy / pyright are not in the
   stack); naming conventions ruff doesn't enforce; setting up
   PostToolUse / PreToolUse hooks; linting non-Python files.
@@ -151,6 +179,48 @@ Audit files (`audit/<NN>_<short_name>.py`, owned by
 convention for any helper functions. After writing or editing one of
 these files, run the same trio (`ruff format` → `ruff check --fix`
 → `ruff check`).
+
+## Contextualize the comments
+
+ruff makes a file *well-formed*; this pass makes it *well-documented
+for the problem*. Templates ship with neutral placeholders and a
+little authoring scaffolding so the generating skill knows what each
+cell / module is for. None of that should survive into the user's
+committed file — the user's files document the **data-science
+problem**, not the process that produced them.
+
+After the ruff trio, for every touched file that now carries **real
+content**, do a quick documentation pass:
+
+1. **Fill the header for this problem.** Replace any `<placeholder>`
+   or generic header with a one- or two-line description of what this
+   file does *here*: the experiment's hypothesis (`experiment.py`),
+   what this module contributes to the pipeline (`src/<pkg>/*.py`),
+   which report this file reviews and what it tests
+   (`audit/<stem>.py`), what the dataset is and what the analysis
+   looks at (`data/eda.py`). Pull the wording from the live context —
+   the project goal, the approved design note, the dataset.
+2. **Strip the workflow meta.** Delete leftover process commentary:
+   skill names, gate IDs (`G-*`), `§` cross-references, "the agent",
+   "the (cell) runner", "the digest", "run cell by cell", journal /
+   backlog / sourcing jargon, and inline guard-rails like "MUST NOT
+   call `put` / bare expressions, don't `print`". Those guard-rails
+   stay enforced — they live in the owning skill's SKILL.md, which is
+   where the agent reads them, not in the user's file.
+3. **Keep the substance.** Genuinely useful problem / engineering
+   context and the numpydoc docstrings stay. Cell markers (`# %%`)
+   and any remaining `<...>` placeholders the agent still has to fill
+   stay until they are filled.
+
+The result should read like a colleague wrote the file for this
+project — not like a generated scaffold. Skip a file that is still an
+empty skeleton (e.g. a freshly scaffolded `src/<pkg>/*.py` with no
+body yet): there is no context to write about until the content
+lands, and the contextualization happens on the edit that fills it.
+
+This pass is **owned here** so the rule is enforced uniformly. Every
+file-writing skill already hands off to this skill after a write;
+that hand-off now also covers contextualizing the comments.
 
 ## Numpydoc — the docstring convention
 

--- a/skills/python-code-style/templates/ruff.toml
+++ b/skills/python-code-style/templates/ruff.toml
@@ -16,9 +16,9 @@ select = ["E", "F", "W", "I", "B", "UP", "D"]
 #         named functions; when they do, the design-note is the doc
 "experiments/**" = ["E402", "B018", "D100", "D103"]
 "audit/**" = ["E402", "B018", "D100", "D103"]
-# `data/eda.py` is the explore-ml-data EDA cell script (one per workspace);
-# same convention, same ignores. The rest of data/ is user-owned and not
-# linted by this stack.
+# `data/eda.py` is the exploratory-data-analysis cell script (one per
+# workspace); same convention, same ignores. The rest of data/ is
+# user-owned and not linted by this stack.
 "data/eda.py" = ["E402", "B018", "D100", "D103"]
 
 [lint.pydocstyle]

--- a/skills/python-env-manager/SKILL.md
+++ b/skills/python-env-manager/SKILL.md
@@ -430,7 +430,13 @@ already ship the jupyter integration.
 |---|---|---|
 | `local` | `pixi add skore` / `conda install -c conda-forge skore` | `uv add "skore[jupyter]"` / `poetry add "skore[jupyter]"` / `pip install "skore[jupyter]"` |
 | `hub` | `pixi add "skore[hub]"` / `conda install -c conda-forge "skore[hub]"` | `uv add "skore[hub,jupyter]"` / `poetry add "skore[hub,jupyter]"` / `pip install "skore[hub,jupyter]"` |
-| `mlflow` | `pixi add "skore[mlflow]"` / `conda install -c conda-forge "skore[mlflow]"` | `uv add "skore[mlflow,jupyter]"` / `poetry add "skore[mlflow,jupyter]"` / `pip install "skore[mlflow,jupyter]"` |
+| `mlflow` | `pixi add "skore[mlflow]" "mlflow>=3"` / `conda install -c conda-forge "skore[mlflow]" "mlflow>=3"` | `uv add "skore[mlflow,jupyter]" "mlflow>=3"` / `poetry add "skore[mlflow,jupyter]" "mlflow>=3"` / `pip install "skore[mlflow,jupyter]" "mlflow>=3"` |
+
+The `mlflow` variant **must pin `mlflow>=3` explicitly** (shown in the
+commands above). The `skore[mlflow]` extra's mlflow lower bound is
+loose, so the solver can otherwise resolve an old mlflow (2.x) that
+the skore MLflow backend does not support — add `mlflow>=3` to the
+install command on conda-forge and PyPI alike.
 
 If the row is absent (workspace not yet bootstrapped through
 `organize-ml-workspace`), route back to that skill's G-SKORE-MODE.
@@ -441,6 +447,9 @@ Do not guess.
   `[hub]` / `[mlflow]` extras cost network deps + infra the
   local-mode user didn't ask for; the variant follows the recorded
   `skore mode:`, not a guess.
+- Installing the `mlflow` variant without the explicit `mlflow>=3`
+  pin. `skore[mlflow]` alone can resolve mlflow 2.x; the skore MLflow
+  backend needs mlflow 3+. Always co-install `mlflow>=3`.
 - Dropping the `jupyter` extra on PyPI installs because the
   install line "looks shorter". The TableReport / `report.*`
   widgets that the audit flow and `evaluate-ml-pipeline` rely on
@@ -484,8 +493,8 @@ If detection found nothing AND the user picked `pixi` via G-ENV-MGR:
    carries `ipython`, `pyright`.
 4. Add Tier 1 deps to `default` (per G-SKORE-MODE table above —
    pixi is conda-forge, so `pixi add skore`, `pixi add
-   "skore[hub]"`, or `pixi add "skore[mlflow]"`; **no `[jupyter]`
-   extra** on pixi).
+   "skore[hub]"`, or `pixi add "skore[mlflow]" "mlflow>=3"`; **no
+   `[jupyter]` extra** on pixi).
 5. Add tabular lib (per G-TABULAR: `pandas pyarrow` or `polars`).
 6. Wire editable workspace package
    (`pixi add --pypi "<pkg> @ ."` then edit to

--- a/skills/python-env-manager/references/bootstrap.md
+++ b/skills/python-env-manager/references/bootstrap.md
@@ -78,13 +78,18 @@ conda-forge by default, so the `[jupyter]` extra is **not** needed
 
 - `skore mode: local`  → `pixi add scikit-learn skrub skore`
 - `skore mode: hub`    → `pixi add scikit-learn skrub "skore[hub]"`
-- `skore mode: mlflow` → `pixi add scikit-learn skrub "skore[mlflow]"`
+- `skore mode: mlflow` → `pixi add scikit-learn skrub "skore[mlflow]" "mlflow>=3"`
+
+The `mlflow` variant pins `mlflow>=3` explicitly: `skore[mlflow]`
+alone can let the solver pick an old mlflow (2.x) the skore MLflow
+backend doesn't support.
 
 For PyPI-based managers running the analogous bootstrap (uv /
 poetry / hatch / pip+venv), substitute `skore[jupyter]` (local),
 `skore[hub,jupyter]` (hub), or `skore[mlflow,jupyter]` (mlflow) —
-see SKILL.md § "Tier 1 install: skore variant per mode" for the
-full source-aware table.
+keeping the `mlflow>=3` pin for the mlflow variant. See SKILL.md
+§ "Tier 1 install: skore variant per mode" for the full source-aware
+table.
 
 If G-SKORE-MODE hasn't fired yet at bootstrap time (rare —
 `organize-ml-workspace` fires it alongside G-PKG-NAME and

--- a/skills/python-env-manager/references/skore_variant.md
+++ b/skills/python-env-manager/references/skore_variant.md
@@ -41,13 +41,28 @@ Combined matrix:
 |---|---|---|
 | `local` | `skore` | `skore[jupyter]` |
 | `hub` | `skore[hub]` | `skore[hub,jupyter]` |
-| `mlflow` | `skore[mlflow]` | `skore[mlflow,jupyter]` |
+| `mlflow` | `skore[mlflow]` + `mlflow>=3` | `skore[mlflow,jupyter]` + `mlflow>=3` |
 
 Why a single combined extra string for PyPI hub / mlflow mode: PEP
 508 allows comma-separated extras (`skore[hub,jupyter]`,
 `skore[mlflow,jupyter]`) and that's the form all four PyPI-based
 managers accept. Splitting into two install calls works too but
 produces two manifest rows, which is noisier than necessary.
+
+### Why the `mlflow>=3` pin
+
+The `skore[mlflow]` extra declares mlflow as a dependency with a loose
+lower bound, so the environment solver can resolve an **old mlflow
+(2.x)** — which the skore MLflow backend (`skore.Project(mode="mlflow",
+...)`) does not support. Co-install an explicit `mlflow>=3` constraint
+so the solver is forced onto mlflow 3+:
+
+- conda-forge: `pixi add "skore[mlflow]" "mlflow>=3"`
+- PyPI: `uv add "skore[mlflow,jupyter]" "mlflow>=3"` (and the poetry /
+  hatch / pip equivalents).
+
+This is a hard requirement of the mlflow variant — the install is
+considered wrong without it.
 
 ## Forbidden
 
@@ -60,6 +75,9 @@ produces two manifest rows, which is noisier than necessary.
   widgets and the TableReport viz silently degrade.
 - Adding `[jupyter]` on conda-forge installs. Redundant — the
   conda-forge package already brings the integration in.
+- Installing `skore[mlflow]` **without** the `mlflow>=3` pin. The
+  solver will happily resolve mlflow 2.x, which the skore MLflow
+  backend does not support — see § "Why the `mlflow>=3` pin".
 
 ## Reading the recorded decision
 
@@ -85,10 +103,10 @@ forbidden by default" — requires explicit user confirmation):
   land additively; existing local-mode reports under `reports/`
   stay on disk but are no longer the active store.
 - **`local` → `mlflow`** (or **`hub` → `mlflow`**): add the mlflow
-  variant — `"skore[mlflow]"` (conda-forge) or
-  `"skore[mlflow,jupyter]"` (PyPI). The prior store's reports stay
-  where they were (disk / Skore Hub) but are no longer the active
-  store.
+  variant **with the pin** — `"skore[mlflow]" "mlflow>=3"`
+  (conda-forge) or `"skore[mlflow,jupyter]" "mlflow>=3"` (PyPI). The
+  prior store's reports stay where they were (disk / Skore Hub) but
+  are no longer the active store.
 - **`hub` / `mlflow` → `local`**: optionally remove the extra to
   slim the env. Per-manager: `pixi remove skore && pixi add skore`
   (conda-forge) or `uv remove skore && uv add "skore[jupyter]"`


### PR DESCRIPTION
Improve and direct what to provide in the generated python files when it comes to comments. We should not have any information about the workflow directed by the agent but instead context about the data science problem at hand.
