### PR TITLE
chore: Update the skore.Project API in the different skills

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -2,7 +2,7 @@
   "name": "probabl-skills",
   "version": "0.5.0",
   "description": "Skills to support Machine Learning experimentation using the Python ecosystem.",
-  "catalog_hash": "d18ac6621b93642fabae808400fcede9b308a0e94088930767573bc16288d4c7",
+  "catalog_hash": "6ab4a031471dffde5fa6fd154f0ef89c03ace85b8875bf1d5bd59c5940412b75",
   "skills": [
     {
       "id": "explore-ml-data",
@@ -92,7 +92,7 @@
       "summary": "An organized workspace to keep track of your experiments.",
       "category": "tooling",
       "subcategory": "project-setup",
-      "hash": "db7a8e361eb335871071ff9167bd41fa749df7f7d676a216a122608c686727cf"
+      "hash": "287691a83056e7c1c3e2b2da13b01d865728130307afd4b76b39359243ae4b61"
     },
     {
       "id": "python-code-style",
@@ -119,7 +119,7 @@
       "summary": "Opinionated one-library-per-job Python stack, organized into mandatory / user-choice / optional / transitive tiers.",
       "category": "reference",
       "subcategory": null,
-      "hash": "c98079d37ccec0a69bba4105673d2da6017c48e460b843fa8faca31928ccec24"
+      "hash": "021f3e2313f895ae9f533ca14e87f2e96ffe0d1a303f2adad2faf87aaf54ca23"
     },
     {
       "id": "python-api",
@@ -128,7 +128,7 @@
       "summary": "Discover the public API of any installed Python package to make agent find their way without bothering your workspace.",
       "category": "reference",
       "subcategory": null,
-      "hash": "811ffe54214f2e524efa5cb71f01adefaef01d95be916762969c0d62a2a80ea4"
+      "hash": "9cffba82c6182caefb600d5671b5cf4941f961b2e2f8271e166159e92484569c"
     }
   ],
   "workflows": [

--- a/skills/data-science-python-stack/references/skore.md
+++ b/skills/data-science-python-stack/references/skore.md
@@ -77,9 +77,9 @@ when you need control beyond what `evaluate`'s arguments expose:
 ## Project API (experiment tracking)
 
 ```python
-project = skore.Project("my_project")
+project = skore.Project(name="my_project", mode="local")
 project.put("baseline", report_or_estimator_or_metric)
-project.get("baseline")
+project.get(report_id)  # by id from project.summarize(), not by key
 ```
 
 Use the Project API as the durable home for everything you produce:

--- a/skills/organize-ml-workspace/SKILL.md
+++ b/skills/organize-ml-workspace/SKILL.md
@@ -160,12 +160,12 @@ Sibling skills (just-in-time):
 | Folder has skore-hub config (`config.toml` / `SKH__*` / cached login) → present only `hub` (or `hub`+`local`), drop `mlflow` | Detected config is detection, not permission (cf. "Pixi on PATH"). The gate must always offer all three; config only sets the default highlight |
 | Substitute `pip install "skore[hub]"` / `"skore[mlflow]"` based on agent guess | Install variant comes from G-SKORE-MODE's recorded answer. `python-env-manager` reads that row, not agent intuition |
 | Silently change `skore mode:` mid-project to "fix" a broken init | Switching orphans existing reports. Always explicit `AskUserQuestion` first |
-| Hub / mlflow substitution but leaving `workspace=` kwarg | `workspace=` is local-only; hub and mlflow reject it (hub raises `TypeError`; mlflow uses `tracking_uri=`). Substitute the whole block, not just the mode literal |
+| Hub substitution but leaving a directory-style `workspace=str(PROJECT_ROOT / "reports")` | In hub mode `workspace=` carries the **Hub workspace name** (e.g. `workspace="acme-corp"`), not an on-disk dir. mlflow rejects `workspace=` and uses `tracking_uri=`. Substitute the whole block, not just the mode literal |
 | mlflow substitution that keeps a `login(mode=...)` call | mlflow mode needs no skore login — auth is the MLflow server's concern. `login` belongs only to hub mode |
 | Local `workspace="reports"` (relative) instead of `str(PROJECT_ROOT / "reports")` (absolute) | Relative resolves against CWD; runs from other dirs write the store somewhere unexpected. Always absolute via `PROJECT_ROOT` |
 | Putting `skore.login(mode="hub")` after `skore.Project(...)` | `Project(...)` requires authenticated session in hub mode. `login` first |
 | Substituting `<SKORE_PROJECT_INIT>` in `audit/<stem>.py` independently of `experiments/<stem>.py` | Audit must open the same Project. Byte-identical copy from the experiment file is the rule |
-| Hub workspace name contains `/` (e.g. `acme/datasci`) | The `/` is reserved as separator. Reject at G-SKORE-MODE follow-up |
+| Hub workspace name contains `/` (e.g. `acme/datasci`) | `workspace=` is a single Hub workspace identifier, not a path or a `<workspace>/<project>` join; a `/` is invalid. Reject at G-SKORE-MODE follow-up |
 | `project.get(key)` raised `KeyError` → re-run `evaluate` + `put` to "recover" | Lookup shape wrong (`get` is by id). Use `summarize()` → `get(id)` |
 
 ## Pre-flight — emit before any code

--- a/skills/organize-ml-workspace/references/g_skore_mode.md
+++ b/skills/organize-ml-workspace/references/g_skore_mode.md
@@ -38,8 +38,9 @@ from skore import login
 login(mode="hub")
 
 project = skore.Project(
-    "<hub-workspace>/<project-name>",
+    name="<project-name>",
     mode="hub",
+    workspace="<hub-workspace>",
 )
 ```
 
@@ -70,9 +71,9 @@ Source: https://docs.skore.probabl.ai/stable/reference/api/skore.Project.html
 |---|---|---|---|
 | `import` line for `login` | not needed | `from skore import login` | not needed |
 | `login(mode="hub")` call | not needed | **required, before `Project(...)`** | not needed |
-| `name=` argument | `name="<project-name>"` (bare) | `"<hub-workspace>/<project-name>"` (positional, slash-joined) | `name="<experiment-name>"` (MLflow experiment name) |
+| `name=` argument | `name="<project-name>"` (bare) | `name="<project-name>"` (bare — the Hub project name) | `name="<experiment-name>"` (MLflow experiment name) |
 | `mode=` argument | `mode="local"` | `mode="hub"` | `mode="mlflow"` |
-| `workspace=` argument | **required**: `workspace=str(PROJECT_ROOT / "reports")` | **MUST be absent** — passing it raises `TypeError` | **MUST be absent** — `tracking_uri=` is used instead |
+| `workspace=` argument | **required**: `workspace=str(PROJECT_ROOT / "reports")` (on-disk dir) | **required**: `workspace="<hub-workspace>"` (the Hub workspace name) | **MUST be absent** — `tracking_uri=` is used instead |
 | `tracking_uri=` argument | not used | not used | **required**: the MLflow tracking server URI |
 | Install variant | `pixi add skore` | `pixi add "skore[hub]"` | `pixi add "skore[mlflow]" "mlflow>=3"` (pin required) |
 | Pre-condition | none | Skore Hub account + access to `<hub-workspace>` | reachable MLflow tracking server at `<uri>` |
@@ -112,13 +113,14 @@ NOT remove `mlflow` or `local` from the list.
    that they need to create or join one at
    https://skore.probabl.ai first.
 
-   **Validation**: the workspace name MUST NOT contain `/` — the
-   slash is reserved as the separator between `<hub-workspace>`
-   and `<project-name>` in the hub-mode `name=` argument (e.g.
-   `"acme-corp/load-forecast"`). If the user types `acme/datasci`,
-   ask whether `acme` was the intended workspace and `datasci` is
-   part of the project name. Do not silently accept slashes — that
-   produces an unparseable Project name at runtime.
+   **Validation**: the workspace name MUST NOT contain `/`. The
+   `workspace=` value is a single Hub workspace identifier passed as
+   its own kwarg (e.g. `workspace="acme-corp"`), not a path and not a
+   `<workspace>/<project>` join — a `/` is not a valid Hub workspace
+   name. If the user types `acme/datasci`, ask whether `acme` was the
+   intended workspace and `datasci` is part of the project name. Do
+   not silently accept slashes — that produces an invalid workspace
+   identifier at runtime.
 
 3. **MLflow tracking URI** (only when mode is `mlflow`). Free-form
    string — the `tracking_uri=` passed to `skore.Project(...)`.
@@ -156,16 +158,18 @@ artifacts:
 
 | Downstream artifact | local-mode shape | hub-mode shape | mlflow-mode shape |
 |---|---|---|---|
-| `<SKORE_PROJECT_INIT>` in `experiments/NN_*.py` and `audit/NN_*.py` | `skore.Project(name="<project-name>", mode="local", workspace=str(PROJECT_ROOT / "reports"))` | `from skore import login; login(mode="hub"); skore.Project("<hub-workspace>/<project-name>", mode="hub")` | `skore.Project(name="<experiment-name>", mode="mlflow", tracking_uri="<mlflow-tracking-uri>")` |
+| `<SKORE_PROJECT_INIT>` in `experiments/NN_*.py` and `audit/NN_*.py` | `skore.Project(name="<project-name>", mode="local", workspace=str(PROJECT_ROOT / "reports"))` | `from skore import login; login(mode="hub"); skore.Project(name="<project-name>", mode="hub", workspace="<hub-workspace>")` | `skore.Project(name="<experiment-name>", mode="mlflow", tracking_uri="<mlflow-tracking-uri>")` |
 | Tier 1 skore install variant (per `python-env-manager` § Tier 1 install) | `pixi add skore` (or equivalent) | `pixi add "skore[hub]"` (or equivalent) | `pixi add "skore[mlflow]" "mlflow>=3"` (or equivalent — the `mlflow>=3` pin is required) |
 | `Workspace decisions` rows in `JOURNAL.md` | `skore mode: local` | `skore mode: hub` + `skore hub workspace: <name>` | `skore mode: mlflow` + `skore mlflow tracking uri: <uri>` |
 
-The `name=` argument shape **changes between modes** — local uses a
-bare name; hub uses `<hub-workspace>/<project>`; mlflow uses the
-MLflow experiment name. The local-mode `workspace=` kwarg points to a
-directory and is rejected by both hub and mlflow modes; mlflow takes
-`tracking_uri=` instead. These are not "swap one word" differences;
-the substitution marker exists precisely because the shape changes.
+`name=` is a bare project name in **all three** modes — local uses it
+directly, hub uses it as the Hub project name, mlflow uses it as the
+MLflow experiment name. What changes is the **companion kwarg**:
+`workspace=` is required by local (an on-disk directory `Path`) and by
+hub (the Hub workspace identifier `str`), while mlflow takes
+`tracking_uri=` instead and rejects `workspace=`. These are not "swap
+one word" differences; the substitution marker exists precisely
+because the companion kwarg changes.
 
 ## Persistence in `Workspace decisions`
 
@@ -252,16 +256,17 @@ from skore import login
 
 login(mode="hub")
 project = skore.Project(
-    "acme-corp/load-forecast",
+    name="load-forecast",
     mode="hub",
+    workspace="acme-corp",
 )
 ```
 
 Note that in the hub form:
 
-- `workspace=` is **gone** (would raise `TypeError`).
-- `name=` becomes positional and uses the slash-joined
-  `<hub-workspace>/<project-name>` shape.
+- `workspace=` is **kept**, but carries the **Hub workspace name**
+  (`"acme-corp"`), not an on-disk directory.
+- `name=` stays the bare project name (no slash join).
 - `login(...)` precedes `Project(...)` in the same cell so a
   single execution does both.
 
@@ -312,10 +317,12 @@ the `audit-ml-pipeline` Forbidden shortcuts row "Substituting
   responsibility — surface that pre-condition rather than spinning
   one up.
 
-- **MLflow `delete`.** `skore.Project.delete(...)` is not
-  implemented for mlflow-mode projects. The read-back contract
-  (`summarize()` → `get(id)`) still holds; deletions must be done
-  through MLflow's own tooling.
+- **Provisioning the MLflow backing store for `delete`.**
+  `skore.Project.delete(name=..., mode="mlflow", tracking_uri=...)`
+  is supported (it removes the matching MLflow experiment), but it
+  raises `LookupError` if no experiment exists at the given
+  `tracking_uri`. This skill does not stand up or seed that server;
+  a reachable tracking store is the user's responsibility.
 
 - **Skore Hub account creation.** The gate assumes the user has an
   account when they pick `hub`. Sign-up is a probabl.ai concern

--- a/skills/python-api/SKILL.md
+++ b/skills/python-api/SKILL.md
@@ -467,9 +467,12 @@ answer.
   data=None, *, splitter=None, ...)` — dispatches by `splitter` to
   `EstimatorReport` (no splitter) / `CrossValidationReport` (CV
   splitter) / `ComparisonReport` (multi-key).
-- **Project**: `skore.Project(workspace=..., name=..., mode=...)`
-  with `put(key, report)` / `summarize()` (DataFrame indexed by id
-  with `key` column) / `get(id)` — **`get` is by id, not by `key`**.
+- **Project**: `skore.Project(name, *, mode="local", **kwargs)`
+  (per-mode kwargs: `workspace=` for local dir / hub workspace name,
+  `tracking_uri=` for mlflow) with `put(key, report)` /
+  `summarize()` (DataFrame indexed by id with `key` column, rows
+  ascending by `date`) / `get(id)` — **`get` is by id, not by
+  `key`** — and static `Project.delete(name, *, mode, **kwargs)`.
 
 Full per-library surface map (rare submodules, accessor cheat sheet):
 → `references/stack_orientation.md`.

--- a/skills/python-api/references/named_traps.md
+++ b/skills/python-api/references/named_traps.md
@@ -25,11 +25,13 @@ installed version via a Shape 1 probe before writing the call.
 
 ## skore
 
-- **`skore.Project(workspace="reports", name="...")`** — the
-  `workspace` keyword is **mode-specific** (`local` mode only).
-  Skipping the docs on `mode=` makes the agent assume `workspace=`
-  is universal. Always look up the `Project` signature against the
-  installed skore.
+- **`skore.Project(workspace=..., name="...")`** — the
+  `workspace` keyword is **mode-specific in meaning**: a directory
+  path in `local` mode, the Hub org/team identifier in `hub` mode,
+  and rejected in `mlflow` mode (which takes `tracking_uri=`
+  instead). Assuming a single universal meaning for `workspace=`
+  silently writes to the wrong store. Always look up the `Project`
+  signature against the installed skore and key off `mode=`.
 - **`skore.evaluate(...)` recursion bug with Rich rendering** —
   when stdout is redirected (CLI contexts), the Rich-rendered
   report can hit a recursion in some versions. Workaround:

--- a/skills/python-api/references/skrub_interop.md
+++ b/skills/python-api/references/skrub_interop.md
@@ -122,7 +122,11 @@ project.put("01_baseline", report)
 # hub mode
 from skore import login
 login(mode="hub")  # interactive on first run; cached after
-project = skore.Project("<hub-workspace>/load-forecast", mode="hub")
+project = skore.Project(
+    name="load-forecast",
+    mode="hub",
+    workspace="<hub-workspace>",  # the Skore Hub org/team identifier
+)
 project.put("01_baseline", report)
 ```
 
@@ -140,18 +144,20 @@ project.put("01_baseline", report)   # key = MLflow run name
   the key in a later run overwrites the previous report — fork into
   a new experiment file if you want both. (In mlflow mode the key
   is the run name under the experiment.)
-- **Local-mode `workspace=str(PROJECT_ROOT / "reports")`** — the
-  on-disk directory where the Project store lives. Created on
-  first `put`. **Not** a valid kwarg in hub or mlflow mode.
+- **`workspace=`** — required by local and hub modes, with a
+  different meaning each: local takes an **on-disk directory**
+  (`str(PROJECT_ROOT / "reports")`, created on first `put`), hub
+  takes the **Skore Hub org/team identifier** (`workspace="<hub-workspace>"`).
+  **Not** a valid kwarg in mlflow mode.
 - **mlflow-mode `tracking_uri=`** — the MLflow tracking server URI
   (HTTP(S) server, `sqlite:///…`, or `file:./mlruns` backend).
   mlflow-only kwarg; no `login()`. `skore[mlflow]` extra required.
-  Note: `project.delete(...)` is not implemented for mlflow-mode
-  projects.
-- **`name=`** — short, stable, per-workspace name. Local mode uses
-  it directly; hub mode uses it after `<hub-workspace>/` as in
-  `"<hub-workspace>/load-forecast"`; mlflow mode uses it as the
-  experiment name. Set once at project bootstrap inside each
+  `project.delete(...)` is supported for mlflow-mode projects (it
+  removes the matching experiment; raises `LookupError` if none
+  exists at the `tracking_uri`).
+- **`name=`** — short, stable, per-workspace name, used directly as
+  the bare project name in **all** modes (mlflow uses it as the
+  experiment name). Set once at project bootstrap inside each
   experiment script's `skore.Project(...)` call (the agent reads
   the value from `experiments/01_baseline.py` when needed; there is
   no auto-discovery script).

--- a/skills/python-api/references/stack_orientation.md
+++ b/skills/python-api/references/stack_orientation.md
@@ -55,32 +55,41 @@ finds the right submodule.
   (for feature importance / coefficients where the estimator
   supports it).
 - **Project**: `skore.Project(name, *, mode='local', **kwargs)`.
-  Three mutually exclusive modes — the constructor args **change
-  shape per mode**:
+  `name=` is the bare project name in **all** modes; what changes is
+  the companion kwarg:
   - **local** (default): `skore.Project(name="<project>",
     mode="local", workspace=str(PROJECT_ROOT / "reports"))`.
-    `workspace=` is a **local-only** kwarg pointing to the on-disk
-    directory; defaults to OS cache dir if omitted. Reports persist
-    locally; no account / login.
+    `workspace=` points to the on-disk directory (`Path`/`str`);
+    defaults to the OS **data** dir if omitted (e.g. macOS
+    `~/Library/Application Support/skore`, Linux
+    `~/.local/share/skore`). Reports persist locally; no account /
+    login.
   - **hub**: `skore.login(mode="hub")` (interactive, first run only)
-    then `skore.Project("<hub-workspace>/<project>", mode="hub")`.
-    `name=` carries the **`<hub-workspace>/<project>`** form where
-    `<hub-workspace>` is a Skore Hub org/team identifier (NOT the
-    local-mode `workspace=` kwarg — skore overloads the term).
-    `workspace=` is rejected (`TypeError`). Requires
+    then `skore.Project(name="<project>", mode="hub",
+    workspace="<hub-workspace>")`. Here `workspace=` carries the
+    **Skore Hub org/team identifier** (a `str`, not a directory —
+    skore overloads the term across modes). Requires
     `pip install "skore[hub]"` and an account on
     https://skore.probabl.ai with access to the workspace.
   - **mlflow**: `skore.Project(name="<experiment>", mode="mlflow",
-    tracking_uri="<uri>")`. `name=` is the MLflow experiment name.
-    Requires `pip install "skore[mlflow]" "mlflow>=3"` (the explicit
+    tracking_uri="<uri>")`. `name=` is the MLflow experiment name;
+    `workspace=` is not accepted. Requires
+    `pip install "skore[mlflow]" "mlflow>=3"` (the explicit
     `mlflow>=3` pin is required — `skore[mlflow]` alone can resolve an
     unsupported mlflow 2.x).
+
+  Read-only attributes: `name`, `mode`, `workspace` (`Path` for
+  local, `str` for hub, `None` for mlflow), `tracking_uri` (`str`
+  for mlflow, `None` otherwise).
 
   Methods (same surface across modes): `put(key, report)`,
   `get(id)` (**by id, not by `key`** — get the id from
   `summarize()`), `summarize()` (returns a pandas DataFrame indexed
   by id with columns including `key`, `learner`, `ml_task`,
-  `report_type`, mean metrics, …), `delete(id)`.
+  `report_type`, mean metrics, … — rows ordered ascending by
+  `date`), and the static `Project.delete(name, *, mode, **kwargs)`
+  (same per-mode kwargs as the constructor; implemented for all
+  three modes incl. mlflow).
 
   Source: https://docs.skore.probabl.ai/stable/reference/api/skore.Project.html
   (skore 0.18.0). The mode choice for this stack's workspaces is


### PR DESCRIPTION
Update the `skore.Project` API in the different skills